### PR TITLE
feat(planning): add branch isolation, git pull, issue creation, and worktree finishing to implementation handoff

### DIFF
--- a/plugins/caf/skills/planning/references/stages/implementation-handoff.md
+++ b/plugins/caf/skills/planning/references/stages/implementation-handoff.md
@@ -61,13 +61,16 @@ If an issue already exists, note its number and continue.
 
 ### 4. Pull latest main
 
-Before creating the worktree, ensure the local base branch is current:
+Before creating the worktree, switch to main and pull to ensure the local base branch is
+current:
 
 ```bash
-git pull origin main
+git checkout main && git pull origin main
 ```
 
-This ensures the new branch forks from the current tip of remote, not a stale local snapshot.
+This ensures the new branch forks from the current tip of remote, not a stale local
+snapshot. Pulling without switching first would merge main into whichever branch is
+currently checked out.
 
 ### 5. Create an isolated workspace
 


### PR DESCRIPTION
## Summary

Four improvements to the implementation handoff stage in `caf:planning`:

- **Step 3:** Check for a linked GitHub issue before handoff; create one if none exists, with a summary of What/Why and a link to the spec file (closes #22)
- **Step 4:** `git checkout main && git pull origin main` before creating the worktree, so the branch always forks from the current remote tip (closes #19)
- **Step 5:** Invoke `superpowers:using-git-worktrees` to create an isolated branch and worktree before implementation; guard against proceeding on main (closes #17)
- **Step 6:** Pass worktree finishing context to `superpowers:finishing-a-development-branch` — suppress local merge option, defer worktree cleanup until after PR merges (closes #20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)