### PR TITLE
feat(planning): create branch at session start, add spec completion prompt

### DIFF
--- a/.eng-docs/specs/backlog/enhancement-planning-impl-intent.md
+++ b/.eng-docs/specs/backlog/enhancement-planning-impl-intent.md
@@ -1,0 +1,66 @@
+---
+created: 2026-04-10
+last_updated: 2026-04-10
+status: implementing
+issue: 39
+specced_by: markdstafford
+implemented_by: markdstafford
+superseded_by: null
+---
+
+# Enhancement: planning impl intent
+
+## Parent feature
+
+`specs/feature-planning.md`
+
+## What
+
+At the start of every planning session, the planning skill creates a feature branch and writes all spec content there. Main is never touched. After the final spec section is approved, the skill asks what to do next: continue to implementation (sets up the worktree and hands off), open a PR for the spec only, or stay on the branch.
+
+## Why
+
+When a user plans and implements in one session, the current workflow writes the spec to main and creates the worktree separately — leaving no clean path forward. Moving the spec after the fact requires manual file moves and an awkward decision: open a PR for just the spec, or carry uncommitted work into the implementation worktree. Always writing the spec to a branch, and asking what to do at the end, eliminates the awkward handoff entirely.
+
+## User stories
+
+- Mark can finish a spec and immediately continue to implementation, with the worktree set up from the same branch the spec was written on
+- Sam can finish a spec and open a PR for it without any manual branch setup, because the spec is already on a feature branch
+- Mark can finish a spec and leave it on the branch to return to later, with no action required
+
+## Design changes
+
+*(Not applicable — no UI changes)*
+
+## Technical changes
+
+### Affected files
+
+- `plugins/mm/skills/planning/SKILL.md` — create a branch before handing off to any stage; add post-approval prompt
+- `plugins/mm/skills/planning/references/stages/implementation-handoff.md` — create worktree from the existing branch rather than creating a new branch
+
+### Changes
+
+In `SKILL.md`, after the stage is identified but before handing off, add:
+
+> Create a branch named for the feature/enhancement (e.g. `feat/[short-name]`) and check it out. All spec content is written here. Main is never touched.
+
+After the final spec section is approved, ask:
+
+> "Spec approved. What next?
+> a. Continue to implementation — I'll set up the worktree and hand off
+> b. Open a PR for the spec only
+> c. Stay on the branch — nothing more needed now"
+
+Route accordingly:
+- **a** → invoke `superpowers:using-git-worktrees` from the existing branch (no new branch needed), then proceed with implementation handoff as normal
+- **b** → create a PR from the spec branch
+- **c** → do nothing; confirm the branch name so the user can return to it later
+
+In `implementation-handoff.md`, step 5, add a guard:
+
+> If the spec was written on a feature branch (i.e. planning was invoked with this enhancement), create the worktree from that branch rather than creating a new one.
+
+## Task list
+
+*(Added by task decomposition stage)*

--- a/plugins/mm/skills/planning/SKILL.md
+++ b/plugins/mm/skills/planning/SKILL.md
@@ -43,9 +43,24 @@ A structured, collaborative process for planning software development work — f
 2. **Create design spec** — design user flows and UI components (default for all features with UI; skip only for backend-only work)
 3. **Write tech spec** — define architecture, APIs, data models, and implementation plan
 4. **Decompose tasks** — break work into implementable tasks with acceptance criteria
-5. **Implementation handoff** — route approved tasks to an implementation system
+5. **Spec completion** — after the task list is approved, ask what to do next (see Spec completion below)
+6. **Implementation handoff** — route approved tasks to an implementation system (only if chosen in step 5)
 
 After completing the workflow, return to step 1 for the next feature.
+
+### Spec completion
+
+After the task list is approved and written to disk, ask:
+
+> "Spec approved. What next?
+> a. Continue to implementation — I'll set up the worktree and hand off
+> b. Open a PR for the spec only
+> c. Stay on the branch — nothing more needed now"
+
+Route accordingly:
+- **a** → invoke `superpowers:using-git-worktrees` from the current branch (do not create a new branch), then proceed with implementation handoff as normal
+- **b** → create a PR from the spec branch to main; confirm the PR URL when done
+- **c** → confirm the branch name so the user can return to it later; do nothing else
 
 ## Shared concepts
 
@@ -78,6 +93,20 @@ Before starting design specs, tech specs, or any stage that builds on prior work
 3. **CHECKPOINT**: Get explicit approval before proceeding to the next section
 4. Never write multiple sections at once
 5. If the human wants to skip ahead, remind them of the process; if they insist, note what was skipped
+
+### Branch setup
+
+Before creating any artifact file, create a branch for this planning session:
+
+1. Choose a short kebab-case name for the work (e.g. `user-auth`, `csv-export`, `planning-impl-intent`)
+2. Create and check out the branch:
+   ```bash
+   git checkout -b feat/[short-name]
+   # or enhancement/[short-name] for enhancements, fix/[short-name] for bug fixes
+   ```
+3. All spec content is written to this branch. Main is never touched.
+
+If the branch already exists or checkout fails, stop and surface the error before proceeding.
 
 ### Artifact file management
 

--- a/plugins/mm/skills/planning/references/stages/implementation-handoff.md
+++ b/plugins/mm/skills/planning/references/stages/implementation-handoff.md
@@ -74,9 +74,9 @@ currently checked out.
 
 ### 5. Create an isolated workspace
 
-Invoke `superpowers:using-git-worktrees` to create a branch and worktree for this
-implementation. Use a branch name derived from the feature or issue (e.g.
-`feat/[short-name]` or `fix/[short-name]`).
+**If arriving here from a planning session** (i.e. the spec was written on a feature branch during this session): invoke `superpowers:using-git-worktrees` using the existing branch — do not create a new one. The spec is already on the right branch.
+
+**If arriving here independently** (e.g. from a GitHub issue, or a spec written in a previous session): invoke `superpowers:using-git-worktrees` to create a new branch and worktree. Use a branch name derived from the feature or issue (e.g. `feat/[short-name]` or `fix/[short-name]`).
 
 **Do not proceed to step 6 if still on main after this step.** If the worktree skill
 leaves the session on main, stop and investigate before continuing.


### PR DESCRIPTION
## Summary

- Planning skill now creates a feature branch before writing any spec content — main is never touched
- After the task list is approved, the skill asks: continue to implementation, open a PR for the spec, or stay on the branch
- Implementation handoff reuses the existing branch when arriving directly from a planning session

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)