### PR TITLE
feat(gardening): add mm:update-wiki, mm:update-spec, and mm:update-specs skills

### DIFF
--- a/.eng-docs/specs/backlog/feature-mm-gardening.md
+++ b/.eng-docs/specs/backlog/feature-mm-gardening.md
@@ -1,0 +1,113 @@
+---
+created: 2026-04-10
+last_updated: 2026-04-10
+status: implementing
+issue: 41
+specced_by: markdstafford
+implemented_by: markdstafford
+superseded_by: null
+---
+
+# mm gardening
+
+## What
+
+mm includes a set of gardening tasks that keep planning artifacts accurate over time. Two tasks ship initially: a wiki freshness review that revisits each wiki document and flags or updates stale content, and a synthesis task that generates and maintains a single top-level spec summarizing what mm is and does, with links out to the individual detail specs. Gardening tasks can be run on demand or on a schedule.
+
+## Why
+
+The most valuable input an AI has is accurate, current context. Specs and wiki documents naturally stagnate — they're written once and rarely updated as the system evolves. Without a way to keep them current, mm's planning artifacts become less useful over time, and the AI assistance they power degrades with them. Gardening tasks solve this by giving mm a structured way to revisit and refresh its own artifacts.
+
+## Personas
+
+- **Mark: Solo developer** — runs gardening tasks after a batch of features ship to keep his specs and wiki current before starting the next planning cycle
+
+## Narratives
+
+### Mark tends his project after a productive sprint
+
+Mark has shipped three features over the past two weeks. The wiki's domain model hasn't been updated since the first feature, and two new entities were added since. He invokes `mm:update-wiki`. The skill reads each wiki document, compares it against the current specs and codebase, and presents a summary of what's stale: two missing entities in the domain model and an outdated API contract. Mark reviews the proposed updates, approves them, and the skill writes the changes.
+
+He then invokes `mm:update-spec`. The skill reads `{docs_root}/spec.md` — the permanent top-level spec that lives alongside the wiki — and compares it against the current detail specs. One feature was deprecated last sprint and still appears in `spec.md`; a new feature shipped but isn't referenced yet. The skill proposes the edits: remove the deprecated feature, add a section for the new one with a link to its detail spec, and update the summary paragraph. Mark reviews, approves, and the skill writes the changes. `spec.md` now reflects exactly what mm does today.
+
+## User stories
+
+- Mark can invoke `mm:update-wiki` to get a summary of stale wiki content and approve proposed updates before they're written
+- Mark can invoke `mm:update-spec` to bring `{docs_root}/spec.md` up to date with current active specs and ADRs
+- Mark can invoke `mm:update-specs` to verify detail specs against the codebase and update any that have drifted, then bring `spec.md` in sync
+- Mark can invoke any of the three skills on demand without disrupting in-progress planning work
+
+## Goals
+
+- `mm:update-wiki` reads all wiki documents, identifies stale content relative to current specs and codebase, and proposes specific edits for human approval before writing anything
+- `mm:update-spec` reads `{docs_root}/spec.md` and all detail specs outside of `backlog/`, proposes edits to keep them in sync (add new features, remove deprecated ones, update links), and writes only after approval
+- Both skills are safe to run at any time — they never write without explicit approval
+- `{docs_root}/spec.md` is created by `mm:update-spec` on first run if it doesn't exist
+
+## Non-goals
+
+- Scheduled / automatic runs (gardening tasks run on demand only in this release)
+- Updating detail specs themselves (these skills only update wiki docs and `spec.md`)
+- Processing specs in `backlog/` — both skills skip unimplemented specs entirely
+
+## Design spec
+
+*(Not applicable — gardening is a skill-based workflow, not a UI feature)*
+
+## Tech spec
+
+### New skills
+
+- `plugins/mm/skills/update-wiki/SKILL.md` — wiki freshness review via codebase scan
+- `plugins/mm/skills/update-spec/SKILL.md` — grooms `spec.md` from active specs and ADRs (shallow)
+- `plugins/mm/skills/update-specs/SKILL.md` — verifies detail specs against the codebase, then runs `mm:update-spec` (deep)
+
+All three skills read `docs_root` from mm config at session start (defaulting to `.eng-docs`).
+
+### `mm:update-wiki` behavior
+
+1. For each wiki document, determine what the codebase actually contains:
+   - `domain-model.md` → scan source files for domain entities, types, and relationships
+   - `database-schema.md` → scan migration files, ORM models, or schema definitions
+   - `api-contracts.md` → scan route definitions and handlers
+   - `design-system.md` → scan component files and style definitions
+2. Compare findings against the current wiki document content
+3. Present a summary of proposed changes per document (additions, removals, corrections)
+4. For each document with changes: show the diff, get approval, write
+
+### `mm:update-spec` behavior
+
+1. Check whether `{docs_root}/spec.md` exists; create a stub if not
+2. Read all active specs in `{docs_root}/specs/` (skip `backlog/`) and all ADRs in `{docs_root}/adrs/`
+3. Identify: features in `spec.md` with no corresponding active spec (candidates for removal), active specs with no entry in `spec.md` (candidates for addition), ADR decisions that should be reflected in the summary
+4. Present proposed changes, get approval, write
+
+### `mm:update-specs` behavior
+
+1. Warn the user that this is a thorough codebase scan that may take several minutes, and confirm before proceeding
+2. Scan the codebase to verify each active spec still accurately describes what's implemented — check for features that have changed, been removed, or diverged from their spec
+2. For each spec with drift, present proposed updates to the detail spec and get approval before writing
+3. Once all detail specs are current, invoke `mm:update-spec` to bring `spec.md` in sync
+
+### `spec.md` structure
+
+YAML frontmatter (`created`, `last_updated`, `status: active`), a brief top-level summary, then one section per feature with a one-paragraph description and a link to the detail spec.
+
+## Task list
+
+**Story 1: `mm:update-wiki` skill**
+- [ ] Create `plugins/mm/skills/update-wiki/SKILL.md` with codebase-scan behavior for all four wiki documents
+  - Acceptance: invoking `mm:update-wiki` on a project with stale wiki docs produces a specific, approvable diff per document; nothing is written without approval
+
+**Story 2: `mm:update-spec` skill**
+- [ ] Create `plugins/mm/skills/update-spec/SKILL.md` with the shallow behavior: read active specs and ADRs, compare against `spec.md`, propose changes
+- [ ] On first run, create `{docs_root}/spec.md` stub with correct frontmatter if it doesn't exist
+  - Acceptance: invoking `mm:update-spec` produces a specific, approvable diff; `spec.md` reflects only active (non-backlog) specs after approval
+
+**Story 3: `mm:update-specs` skill**
+- [ ] Create `plugins/mm/skills/update-specs/SKILL.md` with codebase-scan behavior for each active spec, followed by invocation of `mm:update-spec`; skill warns and confirms before starting
+  - Acceptance: invoking `mm:update-specs` shows a confirmation prompt before doing any work; after confirmation, surfaces drift between code and specs; approved edits are written to detail specs before `spec.md` is updated
+
+**Story 4: Register new skills in plugin manifest**
+- [ ] Add `mm:update-wiki`, `mm:update-spec`, and `mm:update-specs` to `plugins/mm/.claude-plugin/plugin.json`
+  - Acceptance: all three skills appear in the mm skill list after plugin reload

--- a/plugins/mm/.claude-plugin/plugin.json
+++ b/plugins/mm/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "mm",
   "description": "Software development planning workflow. Guides requirements, ADRs, design specs, tech specs, and task decomposition through a structured, collaborative process.",
-  "version": "2.0.0"
+  "version": "2.1.0"
 }

--- a/plugins/mm/skills/update-spec/SKILL.md
+++ b/plugins/mm/skills/update-spec/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: update-spec
+description: >
+  Use when the user wants to keep the top-level spec.md current. Reads all active
+  (non-backlog) specs and ADRs, compares against spec.md, and proposes edits for
+  human approval — adding new features, removing deprecated ones, and updating links.
+  Creates spec.md on first run if it doesn't exist. Use when the user says "update
+  the spec", "update spec.md", "sync the top-level spec", or similar.
+---
+
+# Update spec
+
+Groom `{docs_root}/spec.md` to reflect the current set of active specs and ADRs.
+Nothing is written without human approval.
+
+## Process
+
+### 1. Resolve config
+
+Check for `mm.toml`, `mm.yaml`, or `mm.json` at the repo root (in that order).
+Extract `docs_root` (default: `.eng-docs`).
+
+### 2. Check for spec.md
+
+If `{docs_root}/spec.md` does not exist, create a stub before proceeding:
+
+```markdown
+---
+created: YYYY-MM-DD
+last_updated: YYYY-MM-DD
+status: active
+---
+
+# [Project name]
+
+[One paragraph describing what this project does and who it's for.]
+
+---
+```
+
+Tell the user: *"Created `{docs_root}/spec.md` — will populate it now."*
+
+### 3. Read active specs and ADRs
+
+- Read all spec files in `{docs_root}/specs/` — **skip anything in `backlog/`**
+- Read all ADR files in `{docs_root}/adrs/`
+- Read the current `{docs_root}/spec.md`
+
+### 4. Identify changes
+
+Compare the active specs against `spec.md`:
+
+- **Additions** — active spec files with no corresponding section in `spec.md`
+- **Removals** — sections in `spec.md` with no corresponding active spec file (feature was deprecated or removed)
+- **Link updates** — links in `spec.md` pointing to moved or renamed spec files
+- **ADR surface** — key architectural decisions in ADRs that should be reflected in the top-level summary but aren't
+
+### 5. Present proposed changes
+
+Show a summary of what would change:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+PROPOSED CHANGES TO spec.md
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Add:    ## Configuration  (feature-mm-config.md)
+Add:    ## Gardening      (feature-mm-gardening.md)
+Remove: ## Legacy export  (no active spec found)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+If no changes are needed, report: *"`spec.md` is already in sync — no changes needed."* and stop.
+
+### 6. Show full proposed spec.md
+
+Present the complete proposed `spec.md` content for review — not just the diff. The human should be able to read the whole document and assess it in context.
+
+**CHECKPOINT**: Ask "Write this to `{docs_root}/spec.md`?"
+
+On approval: write the file. Update `last_updated` in frontmatter to today's date.
+On rejection: stop without writing.
+
+## spec.md structure
+
+```markdown
+---
+created: YYYY-MM-DD
+last_updated: YYYY-MM-DD
+status: active
+---
+
+# [Project name]
+
+[1-2 paragraphs: what this project is and who it's for.]
+
+---
+
+## [Feature name]
+
+[1 paragraph: what this feature does and why it matters.]
+
+**Spec:** `specs/feature-[name].md`
+
+---
+
+## [Feature name]
+
+...
+```
+
+One section per active feature spec. Each section has a one-paragraph description and a link to the detail spec. ADRs inform the top-level summary paragraph but are not listed individually.
+
+## Key guidelines
+
+- Only include features with active spec files outside `backlog/`
+- Do not include features that are planned but not yet implemented
+- Keep each feature description to one paragraph — detail belongs in the spec
+- Follow `mm:writing-guidelines` when drafting feature descriptions

--- a/plugins/mm/skills/update-specs/SKILL.md
+++ b/plugins/mm/skills/update-specs/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: update-specs
+description: >
+  Use when the user wants to verify that detail specs still accurately describe
+  what's implemented. Scans the codebase against each active spec, proposes updates
+  for specs that have drifted, then invokes mm:update-spec to bring spec.md in sync.
+  This is a thorough, time-intensive scan — confirm before starting. Use when the
+  user says "update specs", "verify specs", "specs are out of date", or similar.
+---
+
+# Update specs
+
+Verify each active detail spec against the codebase and update any that have drifted.
+After all specs are current, invoke `mm:update-spec` to bring `{docs_root}/spec.md`
+in sync. Nothing is written without human approval.
+
+## Process
+
+### 1. Resolve config
+
+Check for `mm.toml`, `mm.yaml`, or `mm.json` at the repo root (in that order).
+Extract `docs_root` (default: `.eng-docs`).
+
+### 2. Confirm before starting
+
+This skill performs a thorough codebase scan that may take several minutes.
+
+Ask: *"This will scan the codebase against every active spec and may take a few minutes. Proceed?"*
+
+Stop if the user declines.
+
+### 3. Locate active specs
+
+Read all spec files in `{docs_root}/specs/` — **skip anything in `backlog/`**.
+
+If no active specs are found, tell the user and stop.
+
+### 4. Verify each spec against the codebase
+
+For each active spec, scan the relevant parts of the codebase to check whether the spec still accurately describes what's implemented.
+
+Focus on:
+- **Features described but not implemented** — spec describes behavior that doesn't exist in the code
+- **Features implemented but not described** — code has behavior the spec doesn't mention
+- **Changed behavior** — implementation diverges from what the spec says (different API shape, different data model, different user flow)
+- **Removed features** — spec describes something that was deleted
+
+Report findings per spec before proposing any changes:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+feature-github-issue-triage.md
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✓ Up to date
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+feature-planning.md
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Drift found:
+  - User stories reference a "Notes" section that doesn't exist in the skill
+  - Tech spec describes a design spec stage that was removed
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+### 5. Propose and apply updates
+
+For each spec with drift:
+
+1. Show the specific changes needed (which sections to update, what to add or remove)
+2. Show the full proposed updated spec content
+3. **CHECKPOINT**: Ask "Write these changes to `{docs_root}/specs/[filename]`?"
+4. On approval: write the file. Update `last_updated` in frontmatter to today's date.
+5. On rejection: skip and move to the next spec.
+
+Process specs one at a time. Never write without explicit per-spec approval.
+
+### 6. Invoke mm:update-spec
+
+After all specs have been reviewed (whether or not changes were made), invoke `mm:update-spec`
+to bring `{docs_root}/spec.md` in sync with the now-current active specs.
+
+### 7. Report completion
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+UPDATE SPECS COMPLETE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Specs reviewed:  [n]
+Updated:         [n]
+Up to date:      [n]
+Skipped:         [n] (rejected)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+spec.md updated via mm:update-spec
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+## Key guidelines
+
+- Scan the actual codebase — do not compare specs against other specs
+- Focus on behavioral drift, not cosmetic wording differences
+- If the codebase is unclear (e.g. no clear entry point for a feature), ask the human to point to the right files before assessing that spec
+- Follow `mm:writing-guidelines` when drafting updated spec content

--- a/plugins/mm/skills/update-wiki/SKILL.md
+++ b/plugins/mm/skills/update-wiki/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: update-wiki
+description: >
+  Use when the user wants to keep wiki documents current. Scans the codebase
+  to find what domain entities, database schemas, API endpoints, and UI components
+  actually exist, compares against the wiki docs, and proposes specific edits for
+  human approval. Nothing is written without explicit approval. Use when the user
+  says "update the wiki", "refresh the wiki", "wiki is stale", or similar.
+---
+
+# Update wiki
+
+Scan the codebase and refresh the wiki documents in `{docs_root}/wiki/` to reflect
+what the project currently contains. Nothing is written without human approval.
+
+## Process
+
+### 1. Resolve config
+
+Check for `mm.toml`, `mm.yaml`, or `mm.json` at the repo root (in that order).
+Extract `docs_root` (default: `.eng-docs`).
+
+### 2. Locate wiki documents
+
+Check `{docs_root}/wiki/` for the four standard documents:
+
+- `domain-model.md`
+- `database-schema.md`
+- `api-contracts.md`
+- `design-system.md`
+
+Skip any that don't exist. If none exist, tell the user and stop.
+
+### 3. Scan the codebase for each wiki document
+
+For each wiki document present, scan the codebase to determine current state:
+
+**`domain-model.md`**
+- Scan source files for type definitions, interfaces, classes, structs, and enums that represent domain entities
+- Note relationships (foreign keys, references, associations)
+- Focus on the core domain layer — not utilities or infrastructure
+
+**`database-schema.md`**
+- Scan migration files, ORM model definitions, and schema files
+- Note table names, columns, types, constraints, and relationships
+- Check for recent migrations that may have added or removed columns
+
+**`api-contracts.md`**
+- Scan route definitions, controllers, and handler files
+- Note HTTP methods, paths, request/response shapes, and authentication requirements
+- Check for routes that have been added, removed, or changed
+
+**`design-system.md`**
+- Scan component files and style definitions
+- Note component names, props, variants, and design tokens (colors, spacing, typography)
+- Focus on shared/reusable components, not one-off layouts
+
+### 4. Compare and propose changes
+
+For each wiki document, compare scan findings against current document content.
+
+Identify:
+- **Additions** — entities, endpoints, components, or schema elements in the codebase but absent from the wiki
+- **Removals** — items documented in the wiki that no longer exist in the codebase
+- **Corrections** — items documented inaccurately (wrong type, outdated schema, changed behavior)
+
+Present a summary per document:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+domain-model.md
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Add:    Project entity (title, description, owner_id, created_at)
+Add:    Membership entity (user_id, project_id, role)
+Remove: Team entity (no longer exists in codebase)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+If a document is already current, report: *"`domain-model.md` is up to date — no changes needed."*
+
+### 5. Get approval and write
+
+For each document with proposed changes:
+
+1. Show the full proposed updated content (not just the diff) so the human can review in context
+2. **CHECKPOINT**: Ask "Write these changes to `{docs_root}/wiki/[document]`?"
+3. On approval: write the file. Update `last_updated` in the frontmatter to today's date.
+   If the document had `status: stub`, update to `status: active`.
+4. On rejection: skip this document and move to the next.
+
+Process documents one at a time. Never write without explicit per-document approval.
+
+### 6. Report completion
+
+After processing all documents:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+UPDATE WIKI COMPLETE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Updated:   [n] documents
+Skipped:   [n] documents (no changes / rejected)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+## Key guidelines
+
+- The codebase is the source of truth — not the specs. Specs may also be stale.
+- Never infer what should exist from spec files; scan the actual code.
+- If the codebase is unclear (e.g. no migrations found), say so and ask the human to point to the right files before proceeding.
+- Follow `mm:writing-guidelines` when drafting updated wiki content.


### PR DESCRIPTION
## Summary

- `mm:update-wiki` — scans codebase (domain entities, schema, API routes, UI components) against the four wiki documents and proposes per-document edits for human approval
- `mm:update-spec` — grooms `spec.md` from active (non-backlog) specs and ADRs; creates `spec.md` on first run if absent
- `mm:update-specs` — deep scan: verifies each active spec against the codebase for drift, proposes per-spec updates, then invokes `mm:update-spec`; requires upfront confirmation due to scan time

All three skills respect `docs_root` from mm config.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)