### PR TITLE
chore: add mm.toml and move implemented specs out of backlog

### DIFF
--- a/.eng-docs/specs/enhancement-planning-impl-intent.md
+++ b/.eng-docs/specs/enhancement-planning-impl-intent.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-04-10
 last_updated: 2026-04-10
-status: implementing
+status: complete
 issue: 39
 specced_by: markdstafford
 implemented_by: markdstafford

--- a/.eng-docs/specs/feature-mm-config.md
+++ b/.eng-docs/specs/feature-mm-config.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-04-10
 last_updated: 2026-04-10
-status: implementing
+status: complete
 issue: 40
 specced_by: markdstafford
 implemented_by: markdstafford

--- a/.eng-docs/specs/feature-mm-gardening.md
+++ b/.eng-docs/specs/feature-mm-gardening.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-04-10
 last_updated: 2026-04-10
-status: implementing
+status: complete
 issue: 41
 specced_by: markdstafford
 implemented_by: markdstafford

--- a/.eng-docs/specs/feature-planning.md
+++ b/.eng-docs/specs/feature-planning.md
@@ -1,0 +1,56 @@
+---
+created: 2026-04-10
+last_updated: 2026-04-10
+status: draft
+issue: null
+specced_by: markdstafford
+implemented_by: null
+superseded_by: null
+---
+
+# Planning
+
+## What
+
+*(Stub — to be fully specced)*
+
+The planning feature gives developers a structured, collaborative workflow for turning a vague idea into a ready-to-implement plan. It guides users through writing product requirements, design specs, technical specs, and task decomposition — with human-AI checkpoints at each step. It also includes an implementation handoff stage that connects an approved task list to an isolated git worktree and a concrete implementation plan.
+
+## Why
+
+*(Stub — to be fully specced)*
+
+Planning without structure produces decisions that can't be traced, requirements that drift, and implementation that diverges from intent. The planning feature gives every development decision a durable, version-controlled home — so context survives across sessions, handoffs, and collaborators.
+
+## Personas
+
+- **Mark: Solo developer** — uses the full planning workflow to spec and implement features without losing reasoning between sessions
+- **Sam: Software engineer on a small team** — produces planning artifacts clear enough for teammates to review and implement independently
+
+## Narratives
+
+*(Stub — see app.md for initial narratives)*
+
+## User stories
+
+*(Stub — to be filled in)*
+
+## Goals
+
+*(Stub — to be filled in)*
+
+## Non-goals
+
+*(Stub — to be filled in)*
+
+## Design spec
+
+*(Not applicable — planning is a skill-based workflow, not a UI feature)*
+
+## Tech spec
+
+*(Added by tech specs stage)*
+
+## Task list
+
+*(Added by task decomposition stage)*

--- a/mm.toml
+++ b/mm.toml
@@ -1,0 +1,2 @@
+docs_root = ".eng-docs"
+issue_tracker = "github"


### PR DESCRIPTION
## Summary
- Adds `mm.toml` to the repo root with explicit defaults (`docs_root = ".eng-docs"`, `issue_tracker = "github"`)
- Moves the three implemented specs from `specs/backlog/` to `specs/` and marks them `status: complete`
- Adds `feature-planning.md` stub as a parent spec for planning enhancements

## Test plan
- [ ] Verify `mm.toml` exists at repo root with correct content
- [ ] Verify `feature-mm-config.md`, `feature-mm-gardening.md`, and `enhancement-planning-impl-intent.md` are in `specs/` (not `backlog/`)
- [ ] Verify all three have `status: complete` in frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)