### PR TITLE
docs: update specs for gardening/config drift, create spec.md

### DIFF
--- a/.eng-docs/spec.md
+++ b/.eng-docs/spec.md
@@ -1,0 +1,76 @@
+---
+created: 2026-04-10
+last_updated: 2026-04-10
+status: active
+---
+
+# micromanager
+
+micromanager is a Claude Code plugin that gives developers a structured, collaborative
+workflow for planning software development work. It guides users through writing product
+requirements, architectural decision records, design specs, technical specs, and task
+decomposition — with human-AI checkpoints at each step. The plugin also includes utilities
+for issue triage, live feedback capture, and keeping planning artifacts current over time.
+All artifacts are written to a versioned directory inside the project. The directory and
+issue tracker integration are configurable via an `mm.toml` file at the repo root.
+
+---
+
+## Planning
+
+The planning feature guides developers through a structured sequence: product requirements,
+design spec, tech spec, task decomposition, and implementation handoff. Each stage produces
+a durable artifact written to disk and reviewed section by section before moving forward.
+Specs are always written to a feature branch — main is never touched. After the task list
+is approved, the skill asks whether to continue to implementation, open a PR for the spec
+only, or stay on the branch. Implementation handoff creates an isolated git worktree and
+delegates to superpowers for execution.
+
+**Spec:** `specs/feature-planning.md`
+
+---
+
+## Issue triage
+
+The issue triage skill handles two entry points: processing existing unlabeled GitHub issues
+and converting free-form feedback into tracked issues. In repo triage mode it fetches
+unlabeled issues, explores the codebase to build context, rewrites each issue with a precise
+title and enriched body, classifies by type and priority, and writes back to GitHub after
+human approval. In feedback intake mode it accepts bullet lists, verbal notes, or friction
+log files, teases apart distinct items, classifies them, checks for duplicates, and creates
+individual GitHub issues — writing a spec file and committing it before creating the issue
+for features and enhancements. After triage, the skill offers to route directly into the
+appropriate planning workflow.
+
+**Spec:** `specs/feature-github-issue-triage.md`
+
+---
+
+## Configuration
+
+mm reads an optional config file at the repo root — `mm.toml`, `mm.yaml`, or `mm.json` in
+that precedence order. Two settings are supported: `docs_root` sets the base directory for
+all planning artifacts (default: `.eng-docs`), and `issue_tracker` sets the issue tracking
+integration (default: `github`; `jira` is recognized but not yet implemented). All mm skills
+read config at session start and use the resolved values throughout. Missing config or
+unrecognized fields fall back to defaults silently, so existing projects continue to work
+without any migration.
+
+**Spec:** `specs/feature-mm-config.md`
+
+---
+
+## Gardening
+
+The gardening skills keep planning artifacts accurate over time. `mm:update-wiki` scans the
+codebase and proposes specific edits to wiki documents that have drifted from what is
+actually implemented. `mm:update-spec` grooms the top-level `spec.md` by comparing it
+against active feature specs and ADRs, proposing additions, removals, and link fixes.
+`mm:update-specs` is the deep variant: it verifies each active detail spec against the
+codebase, confirms before starting (the scan can take several minutes), proposes updates for
+any specs with behavioral drift, then invokes `mm:update-spec` to bring `spec.md` in sync.
+Nothing is written by any gardening skill without explicit human approval.
+
+**Spec:** `specs/feature-mm-gardening.md`
+
+---

--- a/.eng-docs/specs/app.md
+++ b/.eng-docs/specs/app.md
@@ -1,15 +1,15 @@
 ---
 created: 2026-03-16
-last_updated: 2026-03-16
+last_updated: 2026-04-10
 ---
 
 # micromanager
 
 ## What
 
-micromanager is a Claude Code plugin that gives developers a structured, collaborative workflow for planning software development work. It guides users through writing product requirements, architectural decision records, design specs, technical specs, and task decomposition — with human-AI checkpoints at each step to keep the work grounded and reviewed before moving forward. The plugin also includes utilities for issue triage and live usability feedback capture.
+micromanager is a Claude Code plugin that gives developers a structured, collaborative workflow for planning software development work. It guides users through writing product requirements, architectural decision records, design specs, technical specs, and task decomposition — with human-AI checkpoints at each step to keep the work grounded and reviewed before moving forward. The plugin also includes utilities for issue triage, live usability feedback capture, and keeping planning artifacts current over time.
 
-The plugin is distributed as a git repository and installed into Claude Code, where its skills become available as first-class commands in any development session. All planning artifacts are written to disk in a structured `.eng-docs/` directory inside the project, creating a durable, version-controlled record of every decision made during development.
+The plugin is distributed as a git repository and installed into Claude Code, where its skills become available as first-class commands in any development session. All planning artifacts are written to disk in a structured directory inside the project, creating a durable, version-controlled record of every decision made during development. The directory and issue tracker integration are configurable via an `mm.toml` file at the repo root.
 
 ## Why
 
@@ -52,8 +52,15 @@ With the issues open, Mark asks the skill to route one of them into the planning
 - **Tech specs** — architecture, API design, data models, and implementation plans
 - **Task decomposition** — hierarchical task breakdown with acceptance criteria and dependencies
 - **Implementation handoff** — routes approved task lists to implementation systems
+- **Configuration** — `mm.toml` / `mm.yaml` / `mm.json` at the repo root to set a custom docs directory and issue tracker
 
 ### Issue management
 
 - **Issue triage** — enriches, classifies, and writes GitHub issues from raw feedback or friction logs
 - **Friction log** — captures live usability observations during a testing session for later triage
+
+### Gardening
+
+- **mm:update-wiki** — scans the codebase and proposes updates to wiki documents that have drifted from what's actually implemented
+- **mm:update-spec** — grooms the top-level `spec.md` to reflect current active feature specs and ADRs
+- **mm:update-specs** — deep scan that verifies each detail spec against the codebase, updates any that have drifted, then syncs `spec.md`

--- a/.eng-docs/specs/feature-github-issue-triage.md
+++ b/.eng-docs/specs/feature-github-issue-triage.md
@@ -10,8 +10,6 @@ In **feedback intake mode**, the skill accepts free-form input — bullet lists,
 
 In both modes, after each issue is triaged or created, the skill offers to route immediately into the appropriate planning workflow — bugs to implementation handoff, features and enhancements to `mm:planning`.
 
-> **Note:** This skill is a candidate for renaming to "issue triage" with platform extensibility (GitHub, Linear, etc.) as a planned future enhancement.
-
 ## Why
 
 GitHub issue triage solves a coordination problem: raw issues and feedback are noisy, inconsistently described, and hard to act on. Without a structured triage step, issues accumulate without priority, bugs get conflated with feature requests, and planning workflows start from unclear inputs.


### PR DESCRIPTION
## Summary
- Updates `app.md` to reflect the gardening skills and config support that shipped in recent releases
- Removes an outdated note from `feature-github-issue-triage.md` that said the rename was a future plan (it's already done)
- Creates `.eng-docs/spec.md` on first run of `mm:update-spec`

## Test plan
- [ ] Verify `app.md` has a Gardening section under Related features
- [ ] Verify `app.md` mentions `mm.toml` config support
- [ ] Verify `feature-github-issue-triage.md` has no "candidate for renaming" note
- [ ] Verify `.eng-docs/spec.md` exists with Planning, Issue triage, Configuration, and Gardening sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)