### PR TITLE
fix: correct docs_root default value in planning and issue-triage skills

### DIFF
--- a/plugins/mm/skills/issue-triage/SKILL.md
+++ b/plugins/mm/skills/issue-triage/SKILL.md
@@ -46,7 +46,7 @@ gh auth status
 If `gh` is not authenticated or not installed, stop and tell the user.
 
 Resolve the mm config — check for `mm.toml`, `mm.yaml`, or `mm.json` at the repo root (in that order) and extract:
-- `docs_root` (default: `{docs_root}`) — base directory for friction logs and spec paths
+- `docs_root` (default: `.eng-docs`) — base directory for friction logs and spec paths
 - `issue_tracker` (default: `github`; valid values: `github`, `jira`) — issue tracking integration
 
 If `issue_tracker` is `jira`, all issue creation steps below should output: *"Jira integration not yet implemented — skipping issue creation for this item."* and continue to the next item.

--- a/plugins/mm/skills/planning/SKILL.md
+++ b/plugins/mm/skills/planning/SKILL.md
@@ -77,7 +77,7 @@ done
 ```
 
 Extract from the config file (all fields fall back to defaults if absent or if no config file exists):
-- `docs_root` (default: `{docs_root}`) — base directory for all artifact paths in this session
+- `docs_root` (default: `.eng-docs`) — base directory for all artifact paths in this session
 - `issue_tracker` (default: `github`) — issue tracking integration
 
 Use `{docs_root}` throughout this session wherever a path into the docs directory appears.


### PR DESCRIPTION
## Summary
Both `planning/SKILL.md` and `issue-triage/SKILL.md` showed `{docs_root}` as the literal default for the `docs_root` config setting — a template placeholder where `.eng-docs` should appear. Anyone reading the skill would see a confusing circular reference instead of the actual default.

## Test plan
- [ ] `planning/SKILL.md` Config section shows `docs_root` default as `.eng-docs`
- [ ] `issue-triage/SKILL.md` config extraction shows `docs_root` default as `.eng-docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)