### PR TITLE
feat(init): add mm:init skill and session-start hook

### DIFF
--- a/.eng-docs/specs/backlog/enhancement-mm-init.md
+++ b/.eng-docs/specs/backlog/enhancement-mm-init.md
@@ -2,7 +2,7 @@
 created: 2026-04-11
 last_updated: 2026-04-11
 status: approved
-issue: null
+issue: 51
 specced_by: markdstafford
 implemented_by: null
 superseded_by: null

--- a/.eng-docs/specs/backlog/enhancement-mm-init.md
+++ b/.eng-docs/specs/backlog/enhancement-mm-init.md
@@ -1,0 +1,168 @@
+---
+created: 2026-04-11
+last_updated: 2026-04-11
+status: approved
+issue: null
+specced_by: markdstafford
+implemented_by: null
+superseded_by: null
+---
+
+# Enhancement: mm init
+
+## Parent feature
+
+`specs/feature-mm-config.md`
+
+## What
+
+mm gains an `mm:init` skill that guides teams through their mm configuration. When run directly, it presents each setting with its current value (or the default if not yet configured), lets users review and update any of them, and writes the result to `mm.toml` on confirmation. At session start it runs automatically: if no config exists it walks through full setup; if the config exists but is missing settings added since it was created, it walks through only those; otherwise it exits silently.
+
+## Why
+
+mm's config defaults work well for teams starting from scratch, but there's no guided path for teams adopting mm mid-project. Without `mm:init`, new users either discover `mm.toml` through the docs or silently get defaults that may not match their setup. Teams using a non-default `docs_root` would have to figure out the config schema manually, and any misconfiguration is silent — mm just writes to the wrong directory. A guided init removes that friction and gives teams a correct config before they've run a single skill. The `SessionStart` hook takes this further: teams who add it get a one-time prompt the first time Claude Code opens the project, so setup happens before it can be forgotten.
+
+## User stories
+
+- Sam can run `mm:init` directly to review and update any mm setting, including those not yet configured
+- Sam gets walked through creating `mm.toml` automatically the first time she opens a project that doesn't have one
+- Sam gets prompted only for new settings automatically when they're added in a future mm release, without having to remember to run `mm:init`
+- Sam can skip any prompt during direct invocation to accept the current value or the default
+
+## Design changes
+
+*(Not applicable — no UI changes)*
+
+## Technical changes
+
+### Introduction and overview
+
+**Prerequisites and assumptions**
+- `feature-mm-config.md` — defines the config schema (`docs_root`, `issue_tracker`); this enhancement adds the guided setup experience for that schema
+- No ADR, wiki, or database dependencies
+
+**Goals**
+- A new `mm:init` skill defines the canonical list of mm settings with their defaults and handles both direct and session-start invocation
+- A companion hook script checks `mm.toml` at session start and injects context when action is needed — missing file or missing settings
+- Direct invocation presents all settings for review and update; session-start mode presents only what's missing
+
+**Non-goals**
+- Validating setting values (e.g. confirming `docs_root` exists on disk) — consuming skills handle this
+- Migrating config between file formats
+- Removing settings from an existing config
+
+**Glossary**
+- *Known settings* — the complete list of settings mm supports, defined in the skill and mirrored in the hook script
+- *Session-start mode* — mm:init behavior when triggered by the hook rather than direct user invocation
+
+### Affected files
+
+- `plugins/mm/skills/init/SKILL.md` — new; defines known settings, direct and session-start invocation flows
+- `plugins/mm/hooks/session-start.sh` — new; resolves config, injects values, detects missing settings
+- `plugins/mm/skills/planning/SKILL.md` — remove config resolution block
+- `plugins/mm/skills/issue-triage/SKILL.md` — remove config resolution block
+
+### Changes
+
+**Hook script behavior**
+
+The script runs at session start. It reads `mm.toml` (falling back to `mm.yaml` then `mm.json`) and does two things:
+
+First, resolve config and inject values into session context via `additionalContext`:
+```
+mm config: docs_root=".eng-docs", issue_tracker="github"
+```
+Skills reference these session-context values directly; they no longer need their own config resolution blocks.
+
+Second, check for missing required settings. The known required settings are `docs_root` and `issue_tracker`. Because mm:init always writes all required settings to the config file, any missing key unambiguously means a new setting was added since the last init run. If any are missing → inject additional context: `"mm.toml is missing settings: [list]. Starting mm:init…"` and invoke the init flow for those settings. If all present → exit silently.
+
+**Direct invocation**
+
+When a user runs `mm:init` directly, it presents all known required settings as a numbered list. For each setting it shows the current value and the default:
+
+```
+1. docs_root
+   Current: "docs/eng"  |  Default: ".eng-docs"
+2. issue_tracker
+   Current: "github"  |  Default: "github"
+```
+
+For each, the user can enter a new value, press enter to keep the current value, or type `default` to reset to the default. After confirming, the skill writes `mm.toml` with all settings explicitly. Settings that equal their default are still written, so the file reflects the full config state and the hook can detect future new settings.
+
+**Session-start invocation**
+
+When Claude receives the hook's context injection indicating missing settings:
+- If no config file exists: walk through all required settings in order, confirm each, write `mm.toml`
+- If settings are missing: walk through only the missing ones, then append them to the existing file
+
+In both cases write the file before continuing with the rest of the session.
+
+**Config resolution refactor**
+
+Because the hook now injects resolved config values at session start, the manual config resolution blocks in individual skills become redundant. The `for f in mm.toml mm.yaml mm.json` block and the `docs_root`/`issue_tracker` extraction logic is removed from `planning/SKILL.md` and `issue-triage/SKILL.md`, replaced with: *"Config is resolved at session start by the mm hook and available in session context."*
+
+**Known limitation**
+
+mm:init handles required top-level settings (`docs_root`, `issue_tracker`). Optional structured settings (label taxonomy) and future conditional required settings (e.g. Jira-specific settings required when `issue_tracker = "jira"`) are out of scope. A follow-on issue will address mm:init support for conditional and structured config.
+
+**Alternatives considered**
+
+Keeping per-skill config resolution was considered, but having the hook centralize it removes duplication and ensures every session starts with config already resolved — even for skills that don't explicitly read config today.
+
+**Risks**
+
+Medium. Removing config resolution from skills is a meaningful change to multiple files — a bug in the hook would leave all skills without config values. Mitigated by the hook falling back to defaults on any parse error, matching current behavior.
+
+The hook runs at every session start including resumptions and after `/clear`; since it injects config values every time, sessions are always initialized correctly even after compaction.
+
+## Task list
+
+- [ ] **Story: Create mm:init skill**
+  - [ ] **Task: Write direct invocation flow in `plugins/mm/skills/init/SKILL.md`**
+    - **Description**: Create the init skill file. Define the canonical list of required settings with their defaults (`docs_root`: `.eng-docs`, `issue_tracker`: `github`). The direct invocation flow presents each setting with its current value and the default, allows entering a new value, pressing enter to keep the current value, or typing `default` to reset. Shows a preview of the resulting `mm.toml` before writing. Writes all settings explicitly on confirmation, even those at their defaults.
+    - **Acceptance criteria**:
+      - [ ] Skill file exists at `plugins/mm/skills/init/SKILL.md` with name and description frontmatter
+      - [ ] Known settings section lists `docs_root` (default: `.eng-docs`) and `issue_tracker` (default: `github`)
+      - [ ] Direct invocation flow presents each setting with current value and default
+      - [ ] User can enter a new value, keep current, or type `default` to reset
+      - [ ] Preview of resulting `mm.toml` shown before writing
+      - [ ] `mm.toml` written with all settings on confirmation, even those at default
+    - **Dependencies**: None
+  - [ ] **Task: Add session-start invocation section to `plugins/mm/skills/init/SKILL.md`**
+    - **Description**: Add the session-start flow to the init skill. Two cases: (a) no config file — walk through all settings in order and write `mm.toml`; (b) settings missing from existing config — walk through only the missing ones and append them. In both cases the file is written before the session continues. Include a note on the known limitation: conditional and structured settings (e.g. label taxonomy, future Jira-specific settings) are out of scope.
+    - **Acceptance criteria**:
+      - [ ] Session-start mode section present in the skill, clearly distinct from direct invocation
+      - [ ] No-config case walks through all settings and writes `mm.toml`
+      - [ ] Missing-settings case walks through only missing settings and appends to existing file
+      - [ ] File is written before the rest of the session proceeds
+      - [ ] Known limitation about conditional/structured settings documented in the skill
+    - **Dependencies**: "Write direct invocation flow in `plugins/mm/skills/init/SKILL.md`"
+
+- [ ] **Story: Create session-start hook**
+  - [ ] **Task: Write `plugins/mm/hooks/session-start.sh`**
+    - **Description**: Create the hook script that runs at session start. Read `mm.toml` (falling back to `mm.yaml` then `mm.json`). Inject resolved config values as `additionalContext` (`mm config: docs_root="...", issue_tracker="..."`). Then check for missing required settings: if no config file exists, inject context saying mm:init is needed; if settings are missing, inject context listing them; if all settings present, exit silently. Fall back to defaults on any parse error.
+    - **Acceptance criteria**:
+      - [ ] Script exists at `plugins/mm/hooks/session-start.sh` and is executable
+      - [ ] Reads `mm.toml` first, then `mm.yaml`, then `mm.json`; stops at first found
+      - [ ] Injects resolved config as `additionalContext`: `mm config: docs_root="...", issue_tracker="..."`
+      - [ ] No config file: injects context indicating mm:init is needed
+      - [ ] Config exists but settings missing: injects context listing missing settings
+      - [ ] Config complete: exits silently with no output
+      - [ ] Falls back to defaults on any parse error
+    - **Dependencies**: None
+
+- [ ] **Story: Remove config resolution from existing skills**
+  - [ ] **Task: Remove config resolution block from `plugins/mm/skills/planning/SKILL.md`**
+    - **Description**: Remove the `for f in mm.toml mm.yaml mm.json` config resolution block and the `docs_root`/`issue_tracker` extraction logic. Replace with a note that config is resolved at session start by the mm hook and available in session context. All `{docs_root}` path references in the file stay unchanged.
+    - **Acceptance criteria**:
+      - [ ] Config resolution block removed
+      - [ ] Note present indicating config values come from session context (provided by mm hook)
+      - [ ] All `{docs_root}` path references preserved unchanged
+    - **Dependencies**: "Write `plugins/mm/hooks/session-start.sh`"
+  - [ ] **Task: Remove config resolution block from `plugins/mm/skills/issue-triage/SKILL.md`**
+    - **Description**: Same as the planning skill — remove the config resolution block and replace with a session context reference note.
+    - **Acceptance criteria**:
+      - [ ] Config resolution block removed
+      - [ ] Note present indicating config values come from session context (provided by mm hook)
+      - [ ] All `{docs_root}` path references preserved unchanged
+    - **Dependencies**: "Write `plugins/mm/hooks/session-start.sh`"

--- a/.eng-docs/specs/enhancement-mm-init.md
+++ b/.eng-docs/specs/enhancement-mm-init.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-04-11
 last_updated: 2026-04-11
-status: implementing
+status: complete
 issue: 51
 specced_by: markdstafford
 implemented_by: markdstafford
@@ -117,52 +117,52 @@ The hook runs at every session start including resumptions and after `/clear`; s
 
 ## Task list
 
-- [ ] **Story: Create mm:init skill**
-  - [ ] **Task: Write direct invocation flow in `plugins/mm/skills/init/SKILL.md`**
+- [x] **Story: Create mm:init skill**
+  - [x] **Task: Write direct invocation flow in `plugins/mm/skills/init/SKILL.md`**
     - **Description**: Create the init skill file. Define the canonical list of required settings with their defaults (`docs_root`: `.eng-docs`, `issue_tracker`: `github`). The direct invocation flow presents each setting with its current value and the default, allows entering a new value, pressing enter to keep the current value, or typing `default` to reset. Shows a preview of the resulting `mm.toml` before writing. Writes all settings explicitly on confirmation, even those at their defaults.
     - **Acceptance criteria**:
-      - [ ] Skill file exists at `plugins/mm/skills/init/SKILL.md` with name and description frontmatter
-      - [ ] Known settings section lists `docs_root` (default: `.eng-docs`) and `issue_tracker` (default: `github`)
-      - [ ] Direct invocation flow presents each setting with current value and default
-      - [ ] User can enter a new value, keep current, or type `default` to reset
-      - [ ] Preview of resulting `mm.toml` shown before writing
-      - [ ] `mm.toml` written with all settings on confirmation, even those at default
+      - [x] Skill file exists at `plugins/mm/skills/init/SKILL.md` with name and description frontmatter
+      - [x] Known settings section lists `docs_root` (default: `.eng-docs`) and `issue_tracker` (default: `github`)
+      - [x] Direct invocation flow presents each setting with current value and default
+      - [x] User can enter a new value, keep current, or type `default` to reset
+      - [x] Preview of resulting `mm.toml` shown before writing
+      - [x] `mm.toml` written with all settings on confirmation, even those at default
     - **Dependencies**: None
-  - [ ] **Task: Add session-start invocation section to `plugins/mm/skills/init/SKILL.md`**
+  - [x] **Task: Add session-start invocation section to `plugins/mm/skills/init/SKILL.md`**
     - **Description**: Add the session-start flow to the init skill. Two cases: (a) no config file — walk through all settings in order and write `mm.toml`; (b) settings missing from existing config — walk through only the missing ones and append them. In both cases the file is written before the session continues. Include a note on the known limitation: conditional and structured settings (e.g. label taxonomy, future Jira-specific settings) are out of scope.
     - **Acceptance criteria**:
-      - [ ] Session-start mode section present in the skill, clearly distinct from direct invocation
-      - [ ] No-config case walks through all settings and writes `mm.toml`
-      - [ ] Missing-settings case walks through only missing settings and appends to existing file
-      - [ ] File is written before the rest of the session proceeds
-      - [ ] Known limitation about conditional/structured settings documented in the skill
+      - [x] Session-start mode section present in the skill, clearly distinct from direct invocation
+      - [x] No-config case walks through all settings and writes `mm.toml`
+      - [x] Missing-settings case walks through only missing settings and appends to existing file
+      - [x] File is written before the rest of the session proceeds
+      - [x] Known limitation about conditional/structured settings documented in the skill
     - **Dependencies**: "Write direct invocation flow in `plugins/mm/skills/init/SKILL.md`"
 
-- [ ] **Story: Create session-start hook**
-  - [ ] **Task: Write `plugins/mm/hooks/session-start.sh`**
+- [x] **Story: Create session-start hook**
+  - [x] **Task: Write `plugins/mm/hooks/session-start.sh`**
     - **Description**: Create the hook script that runs at session start. Read `mm.toml` (falling back to `mm.yaml` then `mm.json`). Inject resolved config values as `additionalContext` (`mm config: docs_root="...", issue_tracker="..."`). Then check for missing required settings: if no config file exists, inject context saying mm:init is needed; if settings are missing, inject context listing them; if all settings present, exit silently. Fall back to defaults on any parse error.
     - **Acceptance criteria**:
-      - [ ] Script exists at `plugins/mm/hooks/session-start.sh` and is executable
-      - [ ] Reads `mm.toml` first, then `mm.yaml`, then `mm.json`; stops at first found
-      - [ ] Injects resolved config as `additionalContext`: `mm config: docs_root="...", issue_tracker="..."`
-      - [ ] No config file: injects context indicating mm:init is needed
-      - [ ] Config exists but settings missing: injects context listing missing settings
-      - [ ] Config complete: exits silently with no output
-      - [ ] Falls back to defaults on any parse error
+      - [x] Script exists at `plugins/mm/hooks/session-start.sh` and is executable
+      - [x] Reads `mm.toml` first, then `mm.yaml`, then `mm.json`; stops at first found
+      - [x] Injects resolved config as `additionalContext`: `mm config: docs_root="...", issue_tracker="..."`
+      - [x] No config file: injects context indicating mm:init is needed
+      - [x] Config exists but settings missing: injects context listing missing settings
+      - [x] Config complete: exits silently with no output
+      - [x] Falls back to defaults on any parse error
     - **Dependencies**: None
 
-- [ ] **Story: Remove config resolution from existing skills**
-  - [ ] **Task: Remove config resolution block from `plugins/mm/skills/planning/SKILL.md`**
+- [x] **Story: Remove config resolution from existing skills**
+  - [x] **Task: Remove config resolution block from `plugins/mm/skills/planning/SKILL.md`**
     - **Description**: Remove the `for f in mm.toml mm.yaml mm.json` config resolution block and the `docs_root`/`issue_tracker` extraction logic. Replace with a note that config is resolved at session start by the mm hook and available in session context. All `{docs_root}` path references in the file stay unchanged.
     - **Acceptance criteria**:
-      - [ ] Config resolution block removed
-      - [ ] Note present indicating config values come from session context (provided by mm hook)
-      - [ ] All `{docs_root}` path references preserved unchanged
+      - [x] Config resolution block removed
+      - [x] Note present indicating config values come from session context (provided by mm hook)
+      - [x] All `{docs_root}` path references preserved unchanged
     - **Dependencies**: "Write `plugins/mm/hooks/session-start.sh`"
-  - [ ] **Task: Remove config resolution block from `plugins/mm/skills/issue-triage/SKILL.md`**
+  - [x] **Task: Remove config resolution block from `plugins/mm/skills/issue-triage/SKILL.md`**
     - **Description**: Same as the planning skill — remove the config resolution block and replace with a session context reference note.
     - **Acceptance criteria**:
-      - [ ] Config resolution block removed
-      - [ ] Note present indicating config values come from session context (provided by mm hook)
-      - [ ] All `{docs_root}` path references preserved unchanged
+      - [x] Config resolution block removed
+      - [x] Note present indicating config values come from session context (provided by mm hook)
+      - [x] All `{docs_root}` path references preserved unchanged
     - **Dependencies**: "Write `plugins/mm/hooks/session-start.sh`"

--- a/.eng-docs/specs/enhancement-mm-init.md
+++ b/.eng-docs/specs/enhancement-mm-init.md
@@ -1,10 +1,10 @@
 ---
 created: 2026-04-11
 last_updated: 2026-04-11
-status: approved
+status: implementing
 issue: 51
 specced_by: markdstafford
-implemented_by: null
+implemented_by: markdstafford
 superseded_by: null
 ---
 

--- a/plugins/mm/hooks/session-start.sh
+++ b/plugins/mm/hooks/session-start.sh
@@ -25,8 +25,9 @@ parse_toml_value() {
   { grep -E "^${key}\s*=" "$file" 2>/dev/null || true; } \
     | head -1 \
     | sed -E 's/^[^=]+=\s*//' \
-    | tr -d '"'"'" \
-    | tr -d '[:space:]'
+    | sed -E 's/#[^"]*$//' \
+    | sed -E "s/^['\"]//; s/['\"].*$//" \
+    | sed -E 's/^[[:space:]]+|[[:space:]]+$//'
 }
 
 if [ -z "$CONFIG_FILE" ]; then
@@ -49,8 +50,8 @@ grep -qE "^docs_root\s*=" "$CONFIG_FILE" || MISSING+=("docs_root")
 grep -qE "^issue_tracker\s*=" "$CONFIG_FILE" || MISSING+=("issue_tracker")
 
 if [ ${#MISSING[@]} -gt 0 ]; then
-  MISSING_LIST=$(IFS=", "; echo "${MISSING[*]}")
-  printf '{"additionalContext": "mm config: docs_root=\"%s\", issue_tracker=\"%s\"\n\nmm.toml is missing settings: %s. Starting mm:init to fill them in."}\n' \
+  MISSING_LIST=$(printf '%s, ' "${MISSING[@]}" | sed 's/, $//')
+  printf '{"additionalContext": "mm config: docs_root=\"%s\", issue_tracker=\"%s\"\\n\\nmm.toml is missing settings: %s. Starting mm:init to fill them in."}\n' \
     "$DOCS_ROOT" "$ISSUE_TRACKER" "$MISSING_LIST"
   exit 0
 fi

--- a/plugins/mm/hooks/session-start.sh
+++ b/plugins/mm/hooks/session-start.sh
@@ -56,7 +56,7 @@ if [ ${#MISSING[@]} -gt 0 ]; then
   exit 0
 fi
 
-# All settings present — inject resolved config, exit silently (no mm:init needed)
+# All settings present — inject resolved config values (no mm:init needed)
 printf '{"additionalContext": "mm config: docs_root=\"%s\", issue_tracker=\"%s\""}\n' \
   "$DOCS_ROOT" "$ISSUE_TRACKER"
 exit 0

--- a/plugins/mm/hooks/session-start.sh
+++ b/plugins/mm/hooks/session-start.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# mm session-start hook
+# Resolves mm config and injects values into session context.
+# Detects missing settings and requests mm:init if needed.
+
+set -euo pipefail
+
+# Find config file (mm.toml > mm.yaml > mm.json)
+CONFIG_FILE=""
+for f in mm.toml mm.yaml mm.json; do
+  if [ -f "$f" ]; then
+    CONFIG_FILE="$f"
+    break
+  fi
+done
+
+# Known required settings and their defaults
+DOCS_ROOT_DEFAULT=".eng-docs"
+ISSUE_TRACKER_DEFAULT="github"
+
+# Parse value from TOML key=value line (handles quoted and unquoted values)
+parse_toml_value() {
+  local key="$1"
+  local file="$2"
+  { grep -E "^${key}\s*=" "$file" 2>/dev/null || true; } \
+    | head -1 \
+    | sed -E 's/^[^=]+=\s*//' \
+    | tr -d '"'"'" \
+    | tr -d '[:space:]'
+}
+
+if [ -z "$CONFIG_FILE" ]; then
+  # No config file found — request mm:init
+  printf '{"additionalContext": "No mm.toml found. Starting mm:init to configure mm for this project."}\n'
+  exit 0
+fi
+
+# Parse current values
+DOCS_ROOT=$(parse_toml_value "docs_root" "$CONFIG_FILE")
+ISSUE_TRACKER=$(parse_toml_value "issue_tracker" "$CONFIG_FILE")
+
+# Apply defaults for missing values
+[ -z "$DOCS_ROOT" ] && DOCS_ROOT="$DOCS_ROOT_DEFAULT"
+[ -z "$ISSUE_TRACKER" ] && ISSUE_TRACKER="$ISSUE_TRACKER_DEFAULT"
+
+# Check for missing settings
+MISSING=()
+grep -qE "^docs_root\s*=" "$CONFIG_FILE" || MISSING+=("docs_root")
+grep -qE "^issue_tracker\s*=" "$CONFIG_FILE" || MISSING+=("issue_tracker")
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+  MISSING_LIST=$(IFS=", "; echo "${MISSING[*]}")
+  printf '{"additionalContext": "mm config: docs_root=\"%s\", issue_tracker=\"%s\"\n\nmm.toml is missing settings: %s. Starting mm:init to fill them in."}\n' \
+    "$DOCS_ROOT" "$ISSUE_TRACKER" "$MISSING_LIST"
+  exit 0
+fi
+
+# All settings present — inject resolved config, exit silently (no mm:init needed)
+printf '{"additionalContext": "mm config: docs_root=\"%s\", issue_tracker=\"%s\""}\n' \
+  "$DOCS_ROOT" "$ISSUE_TRACKER"
+exit 0

--- a/plugins/mm/skills/init/SKILL.md
+++ b/plugins/mm/skills/init/SKILL.md
@@ -105,3 +105,37 @@ mm.toml written. mm is configured for this project.
 ```
 
 If the project doesn't have a git repo, skip the commit step and just confirm the file was written.
+
+## Session-start invocation
+
+When Claude receives context from the mm session-start hook indicating action is needed, handle the appropriate case before proceeding with any other session work.
+
+### Case 1: No config file found
+
+Hook context will say: `"No mm.toml found. Starting mm:init to configure mm for this project."`
+
+Walk through all known settings in order using the same steps as direct invocation (steps 1–3), but frame it as first-time setup:
+
+```
+Welcome! mm isn't configured for this project yet. Let's set it up — it takes about a minute.
+```
+
+After writing `mm.toml`, say:
+```
+mm is configured. Continuing with your session.
+```
+
+### Case 2: Missing settings found
+
+Hook context will say: `"mm.toml is missing settings: [list]. Starting mm:init to fill them in."`
+
+Walk through only the listed settings. For each, show the setting name and default value, and prompt for a value or press Enter to accept the default. Append the new settings to the existing `mm.toml` — do not rewrite the whole file; preserve all existing content.
+
+After writing, say:
+```
+mm.toml updated with new settings. Continuing with your session.
+```
+
+### Case 3: Config complete
+
+The hook exits silently when config is complete — no context is injected about mm:init. Take no action; the session proceeds normally.

--- a/plugins/mm/skills/init/SKILL.md
+++ b/plugins/mm/skills/init/SKILL.md
@@ -38,11 +38,12 @@ Check for `mm.toml`, `mm.yaml`, or `mm.json` at the repo root (in that order). I
 
 Show all known settings with current values and defaults:
 
+When config exists with values:
 ```
 mm configuration
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 1. docs_root
-   Current: ".eng-docs"  |  Default: ".eng-docs"
+   Current: "docs/eng"  |  Default: ".eng-docs"
 
 2. issue_tracker
    Current: "github"  |  Default: "github"
@@ -50,9 +51,22 @@ mm configuration
 For each setting: press Enter to keep current value, type a new value, or type "default" to reset.
 ```
 
+When no config exists:
+```
+mm configuration
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+1. docs_root
+   Current: (not set)  |  Default: ".eng-docs"
+
+2. issue_tracker
+   Current: (not set)  |  Default: "github"
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+For each setting: press Enter to use the default, type a new value, or type "default" to use the default.
+```
+
 For each setting in order:
-- Prompt: `docs_root [.eng-docs]: `
-- Accept input: empty → keep current; new value → use it; `default` → use the default
+- Prompt: `docs_root [current value or default]: ` — show the current value in brackets, or the default if not set
+- Accept input: empty → keep current value (or default if unset); new value → use it; `default` → reset to default
 - Repeat for `issue_tracker`
 
 ### 3. Show preview and confirm
@@ -67,7 +81,7 @@ issue_tracker = "github"
 Write mm.toml? (yes / no)
 ```
 
-On `yes`: write `mm.toml` with all settings, then commit:
+On `yes`: check whether the resulting `mm.toml` content would differ from the existing file. If no file existed before, or if the content changed, write `mm.toml` with all settings and commit:
 
 ```bash
 git add mm.toml
@@ -76,9 +90,15 @@ git commit -m "chore: add mm.toml"
 
 (If `mm.toml` already existed and was updated, use `git commit -m "chore: update mm.toml"`.)
 
-On `no`: discard and exit without writing.
+If the content would be identical to the existing file, skip the write and commit and instead say:
 
-### 4. Confirm
+```
+No changes — mm.toml is already up to date.
+```
+
+On `no`: discard and exit without writing. Tell the user: "Cancelled. No changes written."
+
+### 4. Done
 
 ```
 mm.toml written. mm is configured for this project.

--- a/plugins/mm/skills/init/SKILL.md
+++ b/plugins/mm/skills/init/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: init
+description: >
+  Use to set up or update mm configuration for a project. Creates or updates
+  mm.toml with guided prompts for each setting. Also use when invoked automatically
+  at session start to create a missing config or fill in new settings.
+---
+
+# mm init
+
+Guide the user through creating or updating `mm.toml` for this project.
+
+## When to use
+
+- **Direct invocation**: when a user runs `mm:init` to set up mm for the first time or review and update existing settings
+- **Session-start invocation**: when the mm session-start hook detects a missing config file or missing settings and injects context asking for mm:init to run
+
+## Known settings
+
+The following settings are currently supported. Both are required — they are always written to `mm.toml`, even when set to their defaults.
+
+| Setting | Default | Description |
+|---|---|---|
+| `docs_root` | `.eng-docs` | Base directory for all mm artifact output |
+| `issue_tracker` | `github` | Issue tracking integration (`github` or `jira`) |
+
+**Known limitation:** Optional structured settings (e.g. `labels.*`) and future conditional settings (e.g. Jira-specific fields required when `issue_tracker = "jira"`) are out of scope for mm:init. A follow-on enhancement will address these.
+
+## Direct invocation
+
+When a user runs `mm:init` directly:
+
+### 1. Read current config
+
+Check for `mm.toml`, `mm.yaml`, or `mm.json` at the repo root (in that order). If found, parse current values for each known setting. If not found, all settings are unset (will use defaults).
+
+### 2. Present settings for review
+
+Show all known settings with current values and defaults:
+
+```
+mm configuration
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+1. docs_root
+   Current: ".eng-docs"  |  Default: ".eng-docs"
+
+2. issue_tracker
+   Current: "github"  |  Default: "github"
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+For each setting: press Enter to keep current value, type a new value, or type "default" to reset.
+```
+
+For each setting in order:
+- Prompt: `docs_root [.eng-docs]: `
+- Accept input: empty → keep current; new value → use it; `default` → use the default
+- Repeat for `issue_tracker`
+
+### 3. Show preview and confirm
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+PREVIEW: mm.toml
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+docs_root = ".eng-docs"
+issue_tracker = "github"
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Write mm.toml? (yes / no)
+```
+
+On `yes`: write `mm.toml` with all settings, then commit:
+
+```bash
+git add mm.toml
+git commit -m "chore: add mm.toml"
+```
+
+(If `mm.toml` already existed and was updated, use `git commit -m "chore: update mm.toml"`.)
+
+On `no`: discard and exit without writing.
+
+### 4. Confirm
+
+```
+mm.toml written. mm is configured for this project.
+```
+
+If the project doesn't have a git repo, skip the commit step and just confirm the file was written.

--- a/plugins/mm/skills/init/SKILL.md
+++ b/plugins/mm/skills/init/SKILL.md
@@ -114,7 +114,7 @@ When Claude receives context from the mm session-start hook indicating action is
 
 Hook context will say: `"No mm.toml found. Starting mm:init to configure mm for this project."`
 
-Walk through all known settings in order using the same steps as direct invocation (steps 1–3), but frame it as first-time setup:
+Walk through all known settings in order using the same steps as direct invocation (steps 1–3) (including the git commit in step 3; replace step 4's confirmation message with the session-start message below), but frame it as first-time setup:
 
 ```
 Welcome! mm isn't configured for this project yet. Let's set it up — it takes about a minute.
@@ -127,9 +127,13 @@ mm is configured. Continuing with your session.
 
 ### Case 2: Missing settings found
 
-Hook context will say: `"mm.toml is missing settings: [list]. Starting mm:init to fill them in."`
+The hook context will contain a string beginning with `"mm.toml is missing settings:"` followed by a comma-separated list of setting names, for example:
 
-Walk through only the listed settings. For each, show the setting name and default value, and prompt for a value or press Enter to accept the default. Append the new settings to the existing `mm.toml` — do not rewrite the whole file; preserve all existing content.
+`"mm config: docs_root=".eng-docs", issue_tracker="github"\n\nmm.toml is missing settings: issue_tracker. Starting mm:init to fill them in."`
+
+Match on the prefix `"mm.toml is missing settings:"` and extract the setting names that follow (before the period) as the list to walk through.
+
+Walk through only the listed settings. For each, show the setting name and default value, and prompt for a value or press Enter to accept the default. Append the new settings to the existing `mm.toml` — do not rewrite the whole file; preserve all existing content. For each missing setting, prompt the user exactly as in direct invocation Step 2 (show current value as `(not set)` and the default). After all missing settings are collected, append them as new lines at the end of the file and commit without showing a full-file preview — only the new lines are being added.
 
 After writing, say:
 ```

--- a/plugins/mm/skills/init/SKILL.md
+++ b/plugins/mm/skills/init/SKILL.md
@@ -131,7 +131,7 @@ The hook context will contain a string beginning with `"mm.toml is missing setti
 
 `"mm config: docs_root=".eng-docs", issue_tracker="github"\n\nmm.toml is missing settings: issue_tracker. Starting mm:init to fill them in."`
 
-Match on the prefix `"mm.toml is missing settings:"` and extract the setting names that follow (before the period) as the list to walk through.
+Match on the substring `"mm.toml is missing settings:"` anywhere in the context and extract the setting names that follow (before the period) as the list to walk through.
 
 Walk through only the listed settings. For each, show the setting name and default value, and prompt for a value or press Enter to accept the default. Append the new settings to the existing `mm.toml` — do not rewrite the whole file; preserve all existing content. For each missing setting, prompt the user exactly as in direct invocation Step 2 (show current value as `(not set)` and the default). After all missing settings are collected, append them as new lines at the end of the file and commit without showing a full-file preview — only the new lines are being added.
 
@@ -142,4 +142,4 @@ mm.toml updated with new settings. Continuing with your session.
 
 ### Case 3: Config complete
 
-The hook exits silently when config is complete — no context is injected about mm:init. Take no action; the session proceeds normally.
+The hook injects resolved config values (`mm config: docs_root=..., issue_tracker=...`) but no mm:init prompt. Take no init action; the session proceeds normally with the resolved values available in context.

--- a/plugins/mm/skills/issue-triage/SKILL.md
+++ b/plugins/mm/skills/issue-triage/SKILL.md
@@ -45,9 +45,9 @@ gh auth status
 ```
 If `gh` is not authenticated or not installed, stop and tell the user.
 
-Resolve the mm config — check for `mm.toml`, `mm.yaml`, or `mm.json` at the repo root (in that order) and extract:
-- `docs_root` (default: `.eng-docs`) — base directory for friction logs and spec paths
-- `issue_tracker` (default: `github`; valid values: `github`, `jira`) — issue tracking integration
+mm config is resolved at session start by the mm hook and available in session context. The resolved values are:
+- `docs_root` — base directory for friction logs and spec paths
+- `issue_tracker` — issue tracking integration (`github` or `jira`)
 - `labels.type` — type label definitions (default: built-in taxonomy from `references/labels.md`)
 - `labels.priority` — priority label definitions (default: built-in taxonomy from `references/labels.md`)
 - `labels.meta` — meta label definitions (default: built-in taxonomy from `references/labels.md`)

--- a/plugins/mm/skills/issue-triage/SKILL.md
+++ b/plugins/mm/skills/issue-triage/SKILL.md
@@ -45,9 +45,11 @@ gh auth status
 ```
 If `gh` is not authenticated or not installed, stop and tell the user.
 
-mm config is resolved at session start by the mm hook and available in session context. The resolved values are:
+mm config is resolved at session start by the mm hook and available in session context:
 - `docs_root` — base directory for friction logs and spec paths
 - `issue_tracker` — issue tracking integration (`github` or `jira`)
+
+Additionally, read the following directly from config at session start:
 - `labels.type` — type label definitions (default: built-in taxonomy from `references/labels.md`)
 - `labels.priority` — priority label definitions (default: built-in taxonomy from `references/labels.md`)
 - `labels.meta` — meta label definitions (default: built-in taxonomy from `references/labels.md`)

--- a/plugins/mm/skills/planning/SKILL.md
+++ b/plugins/mm/skills/planning/SKILL.md
@@ -68,17 +68,9 @@ These apply across ALL stages. Stage documents reference back here.
 
 ### Config
 
-At the start of every planning session, resolve the mm config:
-
-```bash
-for f in mm.toml mm.yaml mm.json; do
-  [ -f "$f" ] && { CONFIG_FILE="$f"; break; }
-done
-```
-
-Extract from the config file (all fields fall back to defaults if absent or if no config file exists):
-- `docs_root` (default: `.eng-docs`) — base directory for all artifact paths in this session
-- `issue_tracker` (default: `github`) — issue tracking integration
+mm config is resolved at session start by the mm hook and available in session context. The resolved values are:
+- `docs_root` — base directory for all artifact paths in this session
+- `issue_tracker` — issue tracking integration
 
 Use `{docs_root}` throughout this session wherever a path into the docs directory appears.
 


### PR DESCRIPTION
## Summary

- Adds `mm:init` skill for guided mm configuration setup — direct invocation reviews all settings; session-start invocation handles missing config or new settings automatically
- Adds `plugins/mm/hooks/session-start.sh` that resolves mm config at every session start and injects values into session context
- Removes per-skill config resolution blocks from `planning/SKILL.md` and `issue-triage/SKILL.md` — now provided centrally by the hook

## Test Plan

- [ ] Run `mm:init` directly on a project without `mm.toml` — walks through all settings, writes file
- [ ] Run `mm:init` directly on a project with `mm.toml` — shows current values and defaults, allows updating or resetting
- [ ] Add session-start hook to `.claude/settings.json`; open project without `mm.toml` — init runs automatically
- [ ] Open project with complete `mm.toml` — hook injects config values, no init prompt
- [ ] Open project with `mm.toml` missing a setting — hook prompts for only the missing setting
- [ ] Verify `session-start.sh` is executable and outputs valid JSON

Closes #51