### PR TITLE
Add Codex metadata and Autocatalyst config

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "micromanager",
+  "interface": {
+    "displayName": "micromanager"
+  },
+  "plugins": [
+    {
+      "name": "mm",
+      "source": {
+        "source": "local",
+        "path": "./plugins/mm"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
+.env
+.omc/
 node_modules/
 *.log
 .eng-docs/.superpowers-plans/

--- a/README.md
+++ b/README.md
@@ -40,14 +40,10 @@ The `mm:` skills will be available immediately in any project.
 
 **Codex**
 
-Codex does not load Claude plugins directly. Install the underlying skills into `~/.codex/skills`, then restart Codex:
+In Codex, add this repository as a plugin marketplace source:
 
-```bash
-mkdir -p ~/.codex/skills
-ln -s ~/git/coding-agent-flow/plugins/mm/skills/planning ~/.codex/skills/planning
-ln -s ~/git/coding-agent-flow/plugins/mm/skills/issue-triage ~/.codex/skills/issue-triage
-ln -s ~/git/coding-agent-flow/plugins/mm/skills/friction-log ~/.codex/skills/friction-log
-ln -s ~/git/coding-agent-flow/plugins/mm/skills/writing-guidelines ~/.codex/skills/writing-guidelines
+```
+https://github.com/markdstafford/micromanager
 ```
 
-After restarting Codex, invoke `planning`, `issue-triage`, `friction-log`, or `writing-guidelines` directly.
+The `mm` plugin includes Codex metadata and exposes the same skills through the plugin.

--- a/autocatalyst.yaml
+++ b/autocatalyst.yaml
@@ -1,0 +1,79 @@
+workspace:
+  root: ~/.autocatalyst/workspaces/micromanager
+ai:
+  credentials:
+    - name: bedrock
+      type: iam
+      aws_profile: ai-prod-llm
+    - name: grove
+      type: api_key
+      value: ${AC_GROVE_API_KEY}
+  endpoints:
+    - name: grove-anthropic
+      protocol: anthropic
+      base_url: https://grove-gateway-prod.azure-api.net/grove-foundry-prod/anthropic
+      credential: grove
+    - name: grove-openai
+      protocol: openai
+      base_url: https://grove-gateway-prod.azure-api.net/grove-foundry-prod/openai/v1
+      credential: grove
+  profiles:
+    - name: grove-haiku-4.5-low
+      endpoint: grove-anthropic
+      model: claude-haiku-4-5
+      runner: anthropic_direct
+      anthropic:
+        effort: low
+    - name: grove-sonnet-4.6-medium
+      endpoint: grove-anthropic
+      model: claude-sonnet-4-6
+      runner: claude_agent_sdk
+      anthropic:
+        effort: medium
+        thinking: adaptive
+    - name: grove-sonnet-4.6-high
+      endpoint: grove-anthropic
+      model: claude-sonnet-4-6
+      runner: claude_agent_sdk
+      anthropic:
+        effort: high
+        thinking: adaptive
+    - name: grove-sonnet-4.6-low
+      endpoint: grove-anthropic
+      model: claude-sonnet-4-6
+      runner: claude_agent_sdk
+      anthropic:
+        effort: low
+        thinking: adaptive
+  routing:
+    intent.classify: grove-haiku-4.5-low
+    pr.title_generate: grove-haiku-4.5-low
+    artifact.create: grove-sonnet-4.6-high
+    artifact.revise: grove-sonnet-4.6-high
+    implementation.run: grove-sonnet-4.6-medium
+    question.answer: grove-sonnet-4.6-low
+    issue.triage: grove-sonnet-4.6-high
+telemetry:
+  metrics_endpoint: http://localhost:8428/opentelemetry/v1/metrics
+  logs_endpoint: http://localhost:9428/insert/opentelemetry/v1/logs
+  export_interval_ms: 30000
+polling:
+  interval_ms: 30000
+channels:
+  - provider: slack
+    name: ac-micromanager
+    config:
+      bot_token: ${AC_SLACK_BOT_TOKEN}
+      app_token: ${AC_SLACK_APP_TOKEN}
+      user_token: ${AC_SLACK_USER_TOKEN}
+      reacjis:
+        ack: eyes
+publishers:
+  - provider: notion
+    artifacts:
+      - artifact
+      - implementation_feedback
+    config:
+      integration_token: ${AC_NOTION_INTEGRATION_TOKEN}
+      specs_database_id: 09be47fc-74c3-42f0-b85a-fb5bdf7ed6c4
+      testing_guides_database_id: 59def47e-1412-4c6c-b747-8302f2ae07a5

--- a/plugins/mm/.claude-plugin/plugin.json
+++ b/plugins/mm/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "mm",
   "description": "Software development planning workflow. Guides requirements, ADRs, design specs, tech specs, and task decomposition through a structured, collaborative process.",
-  "version": "2.1.0"
+  "version": "2.2.0"
 }

--- a/plugins/mm/.codex-plugin/plugin.json
+++ b/plugins/mm/.codex-plugin/plugin.json
@@ -1,0 +1,39 @@
+{
+  "name": "mm",
+  "version": "2.2.0",
+  "description": "Software development planning workflow. Guides requirements, ADRs, design specs, tech specs, and task decomposition through a structured, collaborative process.",
+  "author": {
+    "name": "Mark Stafford"
+  },
+  "homepage": "https://github.com/markdstafford/micromanager",
+  "repository": "https://github.com/markdstafford/micromanager",
+  "keywords": [
+    "planning",
+    "requirements",
+    "specs",
+    "adrs",
+    "issue-triage",
+    "friction-log",
+    "software-development"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "micromanager",
+    "shortDescription": "Structured planning workflows for software work",
+    "longDescription": "micromanager guides software work from requirements through ADRs, design specs, technical specs, and task decomposition, while keeping decisions in durable repository artifacts.",
+    "developerName": "Mark Stafford",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Use mm planning to turn this feature idea into specs and tasks.",
+      "Use mm issue-triage to classify open GitHub issues.",
+      "Use mm friction-log to capture workflow feedback."
+    ],
+    "websiteURL": "https://github.com/markdstafford/micromanager",
+    "brandColor": "#2563EB"
+  }
+}

--- a/plugins/mm/skills/friction-log/agents/openai.yaml
+++ b/plugins/mm/skills/friction-log/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "mm friction-log"
+  short_description: "Capture live workflow friction"
+  default_prompt: "Use $friction-log to capture friction from this workflow session."

--- a/plugins/mm/skills/init/agents/openai.yaml
+++ b/plugins/mm/skills/init/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "mm init"
+  short_description: "Set up mm project configuration"
+  default_prompt: "Use $init to set up or update mm configuration for this project."

--- a/plugins/mm/skills/issue-triage/agents/openai.yaml
+++ b/plugins/mm/skills/issue-triage/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "mm issue-triage"
+  short_description: "Classify and enrich tracked issues"
+  default_prompt: "Use $issue-triage to triage open issues or turn feedback into GitHub issues."

--- a/plugins/mm/skills/planning/agents/openai.yaml
+++ b/plugins/mm/skills/planning/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "mm planning"
+  short_description: "Plan features into durable artifacts"
+  default_prompt: "Use $planning to turn this feature idea into requirements, specs, and tasks."

--- a/plugins/mm/skills/update-spec/agents/openai.yaml
+++ b/plugins/mm/skills/update-spec/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "mm update-spec"
+  short_description: "Sync the top-level project spec"
+  default_prompt: "Use $update-spec to refresh spec.md from active specs and ADRs."

--- a/plugins/mm/skills/update-specs/agents/openai.yaml
+++ b/plugins/mm/skills/update-specs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "mm update-specs"
+  short_description: "Verify detail specs against code"
+  default_prompt: "Use $update-specs to verify active specs against the codebase."

--- a/plugins/mm/skills/update-wiki/agents/openai.yaml
+++ b/plugins/mm/skills/update-wiki/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "mm update-wiki"
+  short_description: "Refresh wiki docs from code"
+  default_prompt: "Use $update-wiki to refresh wiki documents from the current codebase."

--- a/plugins/mm/skills/writing-guidelines/agents/openai.yaml
+++ b/plugins/mm/skills/writing-guidelines/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "mm writing-guidelines"
+  short_description: "Write clear planning artifacts"
+  default_prompt: "Use $writing-guidelines to review this planning artifact for clarity and tone."


### PR DESCRIPTION
## Summary
- Add Codex plugin marketplace and skill UI metadata for mm
- Bump mm plugin manifests to 2.2.0 and document Codex installation
- Add autocatalyst.yaml and ignore local env/runtime files

Closes #57

## Test Plan
- ruby JSON/YAML parse check for 13 metadata files
- ruby version check for marketplace/plugin metadata
- ruby display-name check matching mm plus skill names
- ruby autocatalyst workspace/channel check