### PR TITLE
Add mm:roadmapping and mm:prototyping skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The skill routes you through design, then a technical spec, then a task list bro
 
 **`mm:planning`** — guides you from a vague idea to an approved task list. Covers requirements, ADRs, design specs, tech specs, and task decomposition, with a checkpoint at every stage.
 
+**`mm:roadmapping`** — plans several related features as a group at a natural inflection point, rather than one at a time. Produces durable architectural docs plus a sequenced backlog of issues, then hands each issue off to `mm:planning`. Use it when planning the next few features together would produce a better architecture than planning each alone.
+
+**`mm:prototyping`** — answers a design question by comparison. Sets up ordered experiments, builds a few variants per experiment that differ on one axis, and folds each winner into the baseline before the next. Works for UI, UX, CLI, API, architecture, and data-model decisions. Composes with `mm:roadmapping` or runs standalone.
+
 **`mm:issue-triage`** — takes raw feedback or a friction log, enriches each item with code context, and writes GitHub issues. Classifies by type and priority; routes bugs and features into the planning workflow.
 
 **`mm:friction-log`** — captures live usability observations during a testing session. Invoke it mid-walkthrough to log what you're seeing without breaking your flow. Feed the log to `mm:issue-triage` when you're done.

--- a/plugins/mm/.claude-plugin/plugin.json
+++ b/plugins/mm/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "mm",
   "description": "Software development planning workflow. Guides requirements, ADRs, design specs, tech specs, and task decomposition through a structured, collaborative process.",
-  "version": "2.2.0"
+  "version": "2.3.0"
 }

--- a/plugins/mm/.codex-plugin/plugin.json
+++ b/plugins/mm/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mm",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Software development planning workflow. Guides requirements, ADRs, design specs, tech specs, and task decomposition through a structured, collaborative process.",
   "author": {
     "name": "Mark Stafford"
@@ -9,6 +9,8 @@
   "repository": "https://github.com/markdstafford/micromanager",
   "keywords": [
     "planning",
+    "roadmapping",
+    "prototyping",
     "requirements",
     "specs",
     "adrs",
@@ -30,6 +32,8 @@
     ],
     "defaultPrompt": [
       "Use mm planning to turn this feature idea into specs and tasks.",
+      "Use mm roadmapping to plan the next several features as a group.",
+      "Use mm prototyping to compare a few approaches to a design question.",
       "Use mm issue-triage to classify open GitHub issues.",
       "Use mm friction-log to capture workflow feedback."
     ],

--- a/plugins/mm/skills/planning/SKILL.md
+++ b/plugins/mm/skills/planning/SKILL.md
@@ -28,6 +28,11 @@ A structured, collaborative process for planning software development work — f
 - **DO use** — for both large and small features (scale the process to fit)
 - **DON'T use the full planning process** — for bug fixes. Use the abbreviated bug workflow in `references/stages/bug-triage.md` instead, which produces a GitHub issue with root cause analysis and a task list.
 - **DON'T use feature requirements** — for improvements to an existing feature; use the enhancement stage instead
+- **DON'T use planning** — for several related features that share architecture and are best planned as a group. Use `mm:roadmapping` instead (see Routing to roadmapping below), then return here per feature.
+
+### Routing to roadmapping
+
+`mm:planning` is scoped to a single feature or enhancement. If, while scoping the work, you find it is really several features that share infrastructure — where planning them together would change the architecture versus planning each alone — stop and route to `mm:roadmapping`. Roadmapping plans the group at an inflection point and files a sequenced backlog of issues; each issue then comes back here for single-feature planning if it is non-trivial.
 
 ## Process overview
 

--- a/plugins/mm/skills/prototyping/SKILL.md
+++ b/plugins/mm/skills/prototyping/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: prototyping
+description: >
+  Use when a design decision has several plausible options worth comparing live instead
+  of in the abstract. Runs ordered experiments; each experiment builds a few variants
+  that differ on one axis, the human picks a winner, and the winner folds into the
+  baseline before the next experiment. Works for visual and UX questions and equally for
+  CLI, API, architecture, and data-model decisions. Use when the user says "prototype",
+  "experiment", "explore options", "compare a few approaches", or "try some variants".
+  Not "build a throwaway version of the whole thing" — that is just exploratory coding.
+  Composes with mm:roadmapping, and runs standalone.
+---
+
+# Prototyping
+
+A structured way to answer a design question by comparison. You set up experiments in a
+rough order. Each experiment builds a few variants that differ on exactly one axis. The
+human picks a winner. **The winner folds into the baseline**, and the next experiment
+builds on top of it. Repeat until the design is settled.
+
+The lab is throwaway. The decisions are what you keep.
+
+## When to use
+
+- **DO use** — when a decision has several plausible options and comparing them live
+  beats arguing them in the abstract.
+- **DO use** — for any kind of decision: visual, UX, CLI, API, architecture, data model.
+- **DO use** — even for a single axis with two variants. The structure scales down.
+- **DON'T use** — when you already know the right answer. Just build it.
+- **DON'T use** — when there is no running system to host a lab. Sketch on paper first
+  and come back when something runs.
+
+## Anti-pattern: bypassing prototyping to ship faster
+
+Skipping comparison to ship a design quickly trades a small saving now for a likely
+rework later, once the unexamined option turns out wrong under real use. Do not bypass
+the process to ship a feature quickly. If the human wants to skip, say what the
+comparison would have caught, then defer to their call:
+
+> "We can commit to the first layout that works, but two of these options behave very
+> differently once the list gets long, and we won't know which until we see them side by
+> side. One experiment — three variants, ten minutes — and we'll know. Skip it, or run
+> it?"
+
+## Process
+
+### 1. Set context
+
+Before planning experiments, establish what you are exploring:
+
+- Are we exploring inside a feature set (composed with `mm:roadmapping`), or a single
+  feature (standalone)?
+- Read the relevant repository docs first — the design system, related features, any
+  existing contracts the design must fit.
+
+Only once the context is clear should you plan experiments. A prototype that ignores the
+existing design system or an adjacent feature's contract wastes a round. Say what
+constraints you found: *"The design system fixes the accent color and the sidebar width,
+so those are constant across all variants — we're only varying the row layout."*
+
+### 2. Plan the experiments
+
+List the axes the design question turns on, and a rough order to explore them. The plan
+is provisional — expect it to change as you learn. Three to seven experiments is typical.
+See `references/experiment-design.md` for choosing and ordering axes.
+
+Order matters: earlier experiments should settle decisions that later ones build on.
+Present the plan and get a loose nod before building — not a formal approval, just
+alignment on where you are headed.
+
+### 3. Set up the lab
+
+Build throwaway scaffolding inside the running system, reachable by a quick toggle — a
+keyboard shortcut, a route flag, an env var, whatever fits the project. Variants live in
+a clearly-named throwaway location so they are easy to find and delete later. See
+`references/lab-setup-patterns.md`.
+
+### 4. Run one experiment
+
+For each experiment, loop:
+
+1. **Identify the axis and the tradeoff** — the one dimension this experiment varies, and
+   what is at stake on it. State it before building.
+2. **Build the variants** — hold everything else constant; vary only this axis. Three
+   variants is the norm. Drop to two when the axis is nearly binary, or go up to about
+   five when the option space is genuinely wider. If you need more than five, the axis is
+   too broad: split it into multiple experiments or run multiple rounds.
+3. **Present** the variants side by side, using the format below.
+4. **Get feedback.** The human either picks a winner, or they do not.
+5. **If no winner**, use their input to build a new set of variants and present again.
+   This is normal — a round that produces no winner is the comparison doing its job.
+6. **On a winner**, fold it into the baseline and delete the losing variant files. The
+   next experiment builds on the new baseline.
+
+#### Variant presentation format
+
+Present every experiment the same way so the human can compare quickly:
+
+```
+Experiment N: <axis> — <the tradeoff at stake>
+Holding constant: <what is the same across all variants>
+
+  A — <name>: <one line on what's different and why you'd pick it>
+  B — <name>: <one line>
+  C — <name>: <one line>
+
+How to see them: <toggle instructions — key, flag, route>
+```
+
+Then stop and let the human look. Do not recommend a winner unless asked — you propose
+the options; the human picks. If asked for your lean, give it with a one-line reason.
+
+### 5. Re-evaluate between experiments
+
+After each experiment, decide what happens next. The plan from step 2 is a starting
+point, not a script. Choose one and say which and why:
+
+- **Continue** to the next planned experiment.
+- **Re-run** the same axis with a fresh set of variants, if the winner raised new
+  questions.
+- **Reorder** the remaining experiments.
+- **Add** an axis the last experiment surfaced.
+- **Stop early** — sometimes the design is settled before the plan is exhausted.
+
+State it plainly: *"Locked in B. That settles the row layout but raises a density
+question I didn't plan — want to run that next, or move to the empty state as planned?"*
+
+### 6. Watch for meta-lessons
+
+Some feedback is not "pick a variant" but "the axis itself is wrong." The most common
+case: your variants are each a different *value* on a dimension, when the real question
+is one level deeper. See `references/meta-lessons.md`. When this happens, accept the
+reframe and rebuild — it is the skill working, not failing.
+
+### 7. Wrap up
+
+When the human calls it, summarize and decide where the decisions land. See
+`references/wrap-up.md`, then clean up the lab per `references/cleanup.md`.
+
+## Key principles
+
+- **One axis at a time.** Variants hold every other dimension constant. If two things
+  vary at once, you cannot attribute the preference.
+- **Three variants is the norm**; two to five as the axis warrants; more than five means
+  split the experiment.
+- **The winner folds into the baseline.** Each experiment builds on the last, so later
+  experiments are judged against real decisions, not a stale starting point.
+- **Lock-in is binary.** Pick one and fold it in. Do not endlessly recombine.
+- **The human picks; you propose.** Never override a pick.
+- **The lab is throwaway.** It never merges to the main line; it is deleted at wrap-up.
+- **Reframes are normal.** A rebuilt trio after a reframe is progress, not waste.
+
+## Composition
+
+When invoked by `mm:roadmapping`, prototyping returns its locked-in decisions to the
+parent instead of writing its own output or asking where decisions land. The parent
+folds them into its architectural docs. Standalone, prototyping handles its own output —
+see `references/wrap-up.md`.
+
+## Writing style
+
+When writing any decision summary or seed doc, follow `mm:writing-guidelines`.

--- a/plugins/mm/skills/prototyping/agents/openai.yaml
+++ b/plugins/mm/skills/prototyping/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "mm prototyping"
+  short_description: "Compare design options through ordered experiments"
+  default_prompt: "Use $prototyping to compare a few approaches to this design question."

--- a/plugins/mm/skills/prototyping/references/cleanup.md
+++ b/plugins/mm/skills/prototyping/references/cleanup.md
@@ -1,0 +1,30 @@
+# Cleanup
+
+The lab is throwaway. Once the decisions are captured (see `wrap-up.md`), remove it.
+
+## What to delete
+
+- All variant files and the throwaway directory they live in.
+- The toggle that activated the lab — the route flag, hidden subcommand, env-var branch,
+  or keybinding.
+- Any fixture data created only for the lab.
+- Lab-only config changes.
+
+## What to preserve
+
+- The decision summary, in whatever destination the wrap-up step chose.
+- Anything the human explicitly asks to promote toward production. Promote it
+  deliberately — rewrite or cherry-pick it into the real code on a proper branch, rather
+  than leaving lab-shaped code behind. Lab code carries throwaway assumptions that should
+  not graduate by accident.
+
+## How to clean up
+
+1. List exactly what you are about to delete, so the human can see it.
+2. Confirm before deleting. Default to yes, but ask — the human may want to keep a
+   variant around for reference.
+3. Delete, and confirm the lab no longer activates (the toggle is gone, the system runs
+   as it did before the lab).
+
+A clean exit leaves the system exactly as it was before the lab, plus the captured
+decisions.

--- a/plugins/mm/skills/prototyping/references/experiment-design.md
+++ b/plugins/mm/skills/prototyping/references/experiment-design.md
@@ -1,0 +1,58 @@
+# Experiment design
+
+An experiment is one axis with a few variants. The quality of a prototyping session is
+mostly decided here: a well-chosen axis produces a clean decision, a muddy axis produces
+variants the human cannot compare.
+
+## Choosing axes
+
+An axis is a single dimension of the design that has several plausible settings. Good
+axes are:
+
+- **Singular** — one dimension, not a bundle. "Row layout" is an axis. "Row layout and
+  density and what shows in the row" is three axes wearing a trenchcoat. Split them.
+- **Consequential** — the choice actually matters and is hard to reverse later. Do not
+  spend an experiment on something a one-line change can flip after the fact.
+- **Comparable** — the variants can be seen side by side and judged. If you cannot show
+  the difference, it is not ready to be an experiment.
+
+If you catch yourself making variants that each set a different *value* of some
+property, the axis is probably one level too shallow — see `meta-lessons.md`.
+
+## Ordering experiments
+
+Order so that earlier decisions constrain later ones, not the other way around:
+
+1. **Structure before surface.** Settle the layout or shape before the styling. A color
+   choice made on the wrong layout is wasted.
+2. **High-leverage before low.** Decisions many later variants depend on come first.
+3. **Cheap-to-reverse last.** Things you can flip in one line can wait.
+
+The order is provisional. Stage 5 of the main loop (re-evaluate) exists precisely so you
+can reorder once a winner changes what matters.
+
+## Designing the variants
+
+- **Hold everything else constant.** Vary only the axis under test. If a second thing
+  changes between variants, the human cannot tell which difference drove their
+  preference.
+- **Make them genuinely different.** Three variants clustered around the same idea waste
+  the round. Spread them across the option space so the comparison is informative — even
+  include one you suspect is wrong, if it sharpens the contrast.
+- **Three is the norm.** Two when the axis is nearly binary. Up to five when the space is
+  genuinely wider. More than five means the axis is too broad — split it or run a second
+  round to narrow first.
+- **Name each variant** for what makes it distinct ("attached titlebar", "footer
+  toggle"), not "A/B/C" alone. The name is how the decision gets remembered.
+
+## When an experiment produces no winner
+
+Not landing a winner is a normal, useful outcome. It usually means one of:
+
+- The variants were too similar — spread them further and re-run.
+- The axis was wrong — the human's feedback points at the real axis (a reframe; see
+  `meta-lessons.md`). Rebuild against it.
+- The decision depends on something not yet settled — pause this experiment, run the
+  prerequisite one first, come back.
+
+Use the human's feedback to decide which, say which, and rebuild.

--- a/plugins/mm/skills/prototyping/references/lab-setup-patterns.md
+++ b/plugins/mm/skills/prototyping/references/lab-setup-patterns.md
@@ -1,0 +1,62 @@
+# Lab setup patterns
+
+The lab is throwaway scaffolding inside the running system that lets the human switch
+between variants quickly. Build the lightest lab that lets you compare variants honestly
+against the real system.
+
+## Principles
+
+- **Inside the real system.** Variants should run against the same tokens, styles, data
+  shapes, and platform mechanics that production uses, so comparisons are honest. A
+  variant that lies about the real environment produces a decision you cannot trust.
+- **Quick toggle.** Switching between variants must be fast — a keypress or a flag, not a
+  rebuild. Slow switching kills comparison.
+- **Clearly throwaway.** Variants live in a clearly-named location that is obviously not
+  production, so they are easy to find and delete later.
+
+## Patterns by surface
+
+- **Web / desktop UI** — a dev-only route or view, gated by a query flag or env var.
+  Numeric keys switch variants. Variant components live in a dedicated throwaway
+  directory and import only existing tokens and shared primitives.
+- **CLI** — a hidden subcommand or a flag that selects the variant behavior. Each variant
+  is a separate handler behind the selector.
+- **API / service** — a variant route or a header/flag that selects the implementation.
+  Each variant is isolated behind the selector so none leaks into the real routes.
+- **Architecture / data model** — a small spike that exercises each variant against
+  realistic data, with the variant selected by config. The goal is to feel the tradeoff,
+  not to ship the spike.
+
+## Worked example — web UI lab
+
+A lab for comparing row layouts in a list view, gated by a query flag, variants switched
+by number keys:
+
+```
+src/lab/                         # clearly-not-production; deleted at wrap-up
+  README.md                      # what this is, how to enter, that it's throwaway
+  Lab.tsx                        # reads ?lab=1, switches variant by number key 1..N
+  registry.ts                    # [{ id, name, Component }]
+  fixtures.ts                    # realistic fixture data, shaped like production
+  variants/
+    1-single-line.tsx
+    2-two-line.tsx
+    3-card.tsx
+```
+
+- `Lab.tsx` mounts only when the flag is present; the real app is untouched otherwise.
+- Each variant imports the real design tokens and shared primitives — no bespoke
+  styling — so what the human sees is what production will feel like.
+- One variant per file keeps them independent: deleting a loser touches nothing else.
+
+The same shape maps to other surfaces: a `--lab=2` flag selecting a CLI handler, a
+`?lab=2` route selecting a service implementation, a config key selecting a data-model
+spike.
+
+## Keep it honest and disposable
+
+- Use real fixture data shaped like production data.
+- Do not wire the lab into real persistence, routing, or side effects.
+- Keep each variant self-contained so it can be deleted without touching the others.
+- Expect to delete all of it at wrap-up. Anything worth keeping is promoted deliberately,
+  not left behind in the lab.

--- a/plugins/mm/skills/prototyping/references/meta-lessons.md
+++ b/plugins/mm/skills/prototyping/references/meta-lessons.md
@@ -1,0 +1,58 @@
+# Meta-lessons
+
+Some feedback in an experiment is not "I pick variant B." It is a signal that the
+experiment is framed wrong. These are the recurring patterns worth watching for. Each
+has a trigger, the reframe, and an example.
+
+## Variants-as-values: the axis is one level deeper
+
+**Trigger.** You find yourself proposing a set of variants where each variant is one
+possible *value* on some dimension. Variant A sorts by date, variant B sorts by
+priority, variant C sorts by status.
+
+**The reframe.** When the variants are just different values, the real design question is
+usually one level up: *how does the user choose the value, and where is that choice
+stored?* The decision is not "which value is right" but "this is a setting the user
+controls" — and then: is it stored per user, per view, per session, or globally?
+
+**Examples.**
+
+- *Sort.* Variants each pick a different sort field. The real axis: sort is a setting the
+  user chooses, not a default the designer hardcodes. The decision becomes where the sort
+  preference lives (per saved view, say), not which field wins.
+- *Filter.* Variants each apply a different filter rule. Same reframe: filtering is a
+  user-controlled setting, and the real question is how filters are defined and persisted,
+  not which single rule is correct.
+
+When you hit this, stop generating value-variants. Surface the reframe to the human, and
+re-aim the experiment at the real axis: the mechanism and its storage scope.
+
+## Variants-that-differ-only-by-content: it is a renderer, not a design choice
+
+**Trigger.** Your variants differ only by *which* entity or content shows up, not by *how*
+anything is presented or behaves.
+
+**The reframe.** Varying only the content means there is no design decision here — there
+is a renderer or component that should be extracted to handle any of that content. The
+work is abstraction, not comparison.
+
+## Detection checklist
+
+Before building a set of variants, sanity-check the axis against these. A "yes" to any
+of them means stop and reframe before building:
+
+- [ ] Is each variant just a different *value* of one property? → The axis is the
+      mechanism for choosing and storing that value, not the value. (Variants-as-values.)
+- [ ] Do the variants differ only by *which* content appears, not *how*? → This is a
+      renderer to extract, not a design choice. (Variants-by-content.)
+- [ ] Could the human reasonably want more than one of these at the same time? → It may
+      be a configurable option, not an either/or decision.
+- [ ] Would the "winner" change depending on the user, the data, or the context? → The
+      real decision is who controls it and where the choice lives.
+
+## Accept the reframe and rebuild
+
+Across all of these, the action is the same: when the human reframes the axis, accept it
+and rebuild the variants against the new axis. A rebuilt set after a reframe is the skill
+working as intended. Do not treat the discarded variants as wasted — they are what
+surfaced the real question.

--- a/plugins/mm/skills/prototyping/references/wrap-up.md
+++ b/plugins/mm/skills/prototyping/references/wrap-up.md
@@ -1,0 +1,58 @@
+# Wrap up
+
+When the human calls the session done, capture the decisions before tearing down the lab.
+
+## 1. Summarize the lock-ins
+
+State, for each experiment that produced a winner:
+
+- The axis the experiment explored.
+- The variant that won.
+- A one-line reason it won.
+
+This summary is the value of the session. It must survive even if everything else is
+deleted. Use this format:
+
+```markdown
+# <design question> — decisions
+
+_From a prototyping session on YYYY-MM-DD._
+
+## <axis 1>
+**Chose:** <variant name>. <one-line reason>.
+Considered: <other variant names>, set aside because <one line>.
+
+## <axis 2>
+**Chose:** <variant name>. <one-line reason>.
+
+## Open / deferred
+- <anything the session surfaced but did not settle>
+```
+
+Record the also-rans, briefly. The reason a variant lost is often the most useful thing
+a future reader learns.
+
+## 2. Decide where the decisions land
+
+**If invoked by `mm:roadmapping`:** skip this step. Return the lock-in summary to the
+parent skill. Roadmapping folds the decisions into its durable `concepts/` docs. Do not
+write your own output doc and do not ask the human where decisions go — the parent owns
+that.
+
+**If standalone:** ask the human where the decisions should land. Offer:
+
+- **a. Fold into an existing durable doc** — the human names the path; you edit it.
+- **b. Seed doc** — write the decision summary to
+  `{docs_root}/notes/<experiment-name>/decisions.md`. This is a working artifact that
+  feeds a later `mm:planning` or `mm:roadmapping` session. It lives under `notes/`, which
+  is gitignored; the human decides whether to keep it under version control.
+- **c. Issue body** — create a new issue, or update an existing one, with the decisions.
+- **d. Just exit** — the human takes the summary from the conversation themselves.
+
+Phrase it as a question: *"Decisions are captured. Where should they live — fold into an
+existing doc, drop a seed doc in `notes/`, put them on an issue, or just leave them
+here?"* Apply `mm:writing-guidelines` to whatever you write.
+
+## 3. Clean up the lab
+
+Proceed to `cleanup.md`.

--- a/plugins/mm/skills/roadmapping/SKILL.md
+++ b/plugins/mm/skills/roadmapping/SKILL.md
@@ -1,0 +1,404 @@
+---
+name: roadmapping
+description: >
+  Use when planning the next several features together rather than one feature at
+  a time — setting course for a feature set, plotting a roadmap, doing long-term or
+  look-ahead planning, or planning a group of related work that shares architecture.
+  Produces durable architectural docs plus a sequenced backlog of issues. Use when
+  the user says "roadmap", "plan the next few features", "plan ahead", "set course",
+  "feature set", or "plan this group of work". Distinct from mm:planning, which is
+  scoped to a single feature or enhancement — roadmapping plans several features at an
+  inflection point and hands each one off afterward.
+---
+
+# Roadmapping
+
+A collaborative process for planning a feature set — several related features that
+share architecture — at a natural inflection point in a project. Roadmapping produces
+two things: durable architectural docs that future work reads from, and a sequenced
+backlog of issues, each ready to hand off to single-feature implementation.
+
+Roadmapping is exploratory at the start and precise at the end. The human is most
+involved early, while goals and concepts are still loose, and least involved late,
+once the concepts are crisp enough to write down. Your job is to help them land an
+excellent feature set, keep them on track, and push back when the design could be
+better.
+
+## When to use
+
+- **DO use** — when several upcoming features share infrastructure that has not been
+  named yet, and planning them as a group will produce a better architecture than
+  planning each alone.
+- **DO use** — at a project inflection point (see `references/inflection-points.md`),
+  where a group of work forms a natural planning boundary.
+- **DON'T use** — for a single feature or enhancement. Use `mm:planning` instead.
+- **DON'T use** — to "boil the ocean." If the work spans dozens of features, it is too
+  large for one roadmapping session; help the human find the nearest inflection point
+  and scope to that.
+
+## Routing
+
+**In from `mm:planning`:** If a planning session reveals the work is really several
+features sharing architecture, stop and route here. Plan the group first, then return
+to `mm:planning` per feature.
+
+**Out to `mm:planning`:** After issues are filed, an individual issue can be picked up
+by `mm:planning` if it is non-trivial. This is usually unnecessary — the session-prep
+docs this skill produces already decompose each issue.
+
+## Anti-pattern: bypassing roadmapping to ship faster
+
+Rushing a feature set into code without setting course feels faster, but the cost is
+paid later — usually as a rewrite, because the shared architecture was guessed at one
+feature at a time instead of designed once. If the human asks to skip roadmapping for a
+group of related work, push back once with the concrete cost, then defer to their call.
+
+The push-back should be specific, not a lecture. Name the architectural decision that
+will be hard to reverse:
+
+> "We can skip ahead and build the first source now, but every later source will inherit
+> whatever shape we give this one. If we plan the source layer as a group first — even
+> just for an hour — the abstraction comes out right the first time. Your call: skip, or
+> set course first?"
+
+## Config
+
+mm config is resolved at session start by the mm hook and available in session context:
+
+- `docs_root` — base directory for all artifact paths in this session
+- `issue_tracker` — issue tracking integration
+
+Use `{docs_root}` throughout wherever a path into the docs directory appears.
+
+## Artifacts and where they live
+
+Roadmapping produces two tiers of document. The distinction is the core of this skill;
+read `references/artifact-tiers.md` for the full model and templates.
+
+- **Durable docs** → `{docs_root}/concepts/`. Committed. These are the architectural
+  contracts that future work reads to understand the shared design. Audience: anyone
+  implementing one of the issues, anyone reviewing the architecture later.
+- **Ephemeral docs** → `{docs_root}/notes/<roadmap-name>/`. Gitignored. Working notes,
+  follow-ups, and per-issue session prep that becomes issue bodies. Audience: the agent
+  running a specific implementation session.
+
+```
+{docs_root}/
+  concepts/                      # durable architectural contracts (COMMITTED)
+    <concept>.md
+  notes/                         # ephemeral working output (GITIGNORED)
+    roadmap-YYYY-MM-DD/          # one folder per roadmapping session
+      brainstorm.md              # loose thinking captured during stages 1-2
+      follow-ups.md              # out-of-scope tangents held for later
+      session-prep/              # one prep doc per issue; becomes the issue body
+        <issue-slug>.md
+```
+
+On first use, ensure `{docs_root}/notes/` is listed in `.gitignore`. If it is not, add
+it and tell the human: *"Added `{docs_root}/notes/` to `.gitignore` — roadmapping's
+working notes stay local; only `concepts/` is committed."* `{docs_root}/concepts/` is
+committed and must not be gitignored.
+
+## File setup and naming
+
+Start without a name. The roadmap's real name emerges from the conversation, so do not
+force one up front. This mirrors `mm:friction-log`: begin with a dated stub, rename once
+the work has an identity.
+
+### 1. Create the session notes at the start of stage 1
+
+Create `{docs_root}/notes/roadmap-YYYY-MM-DD/` and seed it with two files before saying
+anything else to the human.
+
+`brainstorm.md` stub:
+
+```markdown
+---
+created: YYYY-MM-DD
+last_updated: YYYY-MM-DD
+status: exploring
+roadmap: null
+---
+
+# Roadmap brainstorm — YYYY-MM-DD
+
+## Goal
+
+_(stage 1 — what the app can do at the end that it cannot today)_
+
+## Open questions
+
+## Decisions
+
+---
+```
+
+`follow-ups.md` stub:
+
+```markdown
+---
+created: YYYY-MM-DD
+last_updated: YYYY-MM-DD
+---
+
+# Follow-ups — out of scope for this roadmap
+
+_Captured so nothing is lost. Resolved at wrap-up: each becomes its own issue, input to
+a future roadmap, or is discarded._
+
+---
+```
+
+Then tell the human: *"Starting a roadmap session — capturing notes in
+`{docs_root}/notes/roadmap-YYYY-MM-DD/`."*
+
+### 2. Write as you go
+
+Append loose thinking, open questions, and decisions to `brainstorm.md` as the
+conversation proceeds. Do not buffer — if the session ends early, the file should hold
+everything decided to that point.
+
+### 3. Rename at framing (stage 4)
+
+Once the feature set has a clear identity, propose: *"This roadmap is about <topic>.
+Rename the session folder to `roadmap-<slug>`?"* On approval:
+
+```bash
+mv {docs_root}/notes/roadmap-YYYY-MM-DD {docs_root}/notes/roadmap-<slug>
+```
+
+Set the `roadmap` frontmatter field in `brainstorm.md` to `<slug>`.
+
+## Roles
+
+You play different roles across the stages. Each has a goal and a tone.
+
+- **Facilitator** (stages 1–2) — draw out the human's goal, keep them on track, capture
+  tangents. Curious and generative, never passive.
+- **Devil's advocate** (stages 2, 4) — name weaknesses, surface what could go wrong,
+  propose alternatives. Direct but not contrarian for its own sake.
+- **Architect** (stages 3–4) — name concepts, draw boundaries, resolve dependencies.
+  Precise and opinionated.
+- **Author** (stage 5) — turn the framed concepts into durable docs and sequenced
+  issues. The human reviews; you write.
+
+## Working with your human
+
+- Be a partner, not a sycophant. Identify weaknesses and propose alternatives.
+- Get the goal — what the app can do at the end that it could not at the start — from
+  the human. This requires their input; do not invent it.
+- Keep them on track. Roadmapping invites tangents; capture out-of-scope thoughts in
+  `follow-ups.md` so nothing feels lost, then return to the current topic.
+- The human has final say on scope, architecture, and sequencing.
+- Be pleasant to work with. This matters most during open-ended roadmapping.
+- Offload read-heavy research to a sub-agent so the main session stays focused on the
+  human and the design. See `references/research-offload.md`.
+
+## Checkpoints
+
+Roadmapping uses per-section checkpoints. Complete one stage's work, write it to disk,
+present it, and get explicit approval before the next. Never run several stages at once.
+Each checkpoint below is phrased as the question you must be able to answer "yes" to —
+ask it of the human in roughly these words and wait for an answer before proceeding. If
+the human wants to skip ahead, remind them of the process; if they insist, note in
+`brainstorm.md` what was skipped.
+
+## Process
+
+The process moves from loose to crisp across five stages. Stages 1, 2, and 4 are highly
+interactive. Stage 3 may hand off to `mm:prototyping`. Stage 5 is agent-led.
+
+### Stage 1 — Establish the goal
+
+**Role: Facilitator.**
+
+Read the existing system thoroughly first: specs in `{docs_root}/specs/`, ADRs in
+`{docs_root}/adrs/`, wiki in `{docs_root}/wiki/`, and existing docs in
+`{docs_root}/concepts/`. You cannot plan a feature set well without understanding what
+is already there. Summarize back to the human what you found so they can correct your
+model before you build on it.
+
+Then work with the human to define the goal:
+
+- What can the app do at the end of this feature set that it cannot do today?
+- What changes for the user?
+- Sanity-check the bounding. If this is effectively one feature, route to `mm:planning`.
+  If it is dozens of features, it is too large — find the nearest inflection point.
+
+Teach the inflection-point concept if the human is unsure where the boundary is. See
+`references/inflection-points.md`. Write the agreed goal into `brainstorm.md` under
+`## Goal`.
+
+**Checkpoint:** Ask, in roughly these words:
+
+> "Here's the scope as I understand it: <one-paragraph restatement>. Three checks before
+> we go deeper: (1) Is this the right inflection point — not so small it's really one
+> feature, not so big it's several roadmaps? (2) Is it internally one thing? (3) Should
+> we plan this *now*, or does something else need to land first before we can plan it
+> well? What do you think?"
+
+Do not proceed until the human confirms the scope and the timing.
+
+### Stage 2 — Brainstorm
+
+**Roles: Facilitator + Devil's advocate.**
+
+Help the human flesh out the feature set. This is exploratory: surface options, question
+assumptions, and find the shape of the work. Be opinionated about quality while staying
+pleasant.
+
+- Capture every out-of-scope tangent in `follow-ups.md` rather than chasing it. When you
+  do, say so briefly: *"That's worth doing but it's outside this roadmap — parked it in
+  follow-ups so we don't lose it."*
+- Surface shared infrastructure as it appears — the things several features will depend
+  on are the reason to plan as a group. Call them out explicitly when you spot them.
+- Play devil's advocate on at least the load-bearing decisions: what breaks this design,
+  what does it cost, what is the alternative.
+- Write decisions and open questions to `brainstorm.md` as you go.
+
+**Checkpoint:** Ask, in roughly these words:
+
+> "Before we get precise, two checks: is the feature set internally consistent — do the
+> pieces fit together — and does anything in here need to land before the rest? I think
+> we have enough to <prototype X / start naming the architecture>. Agree?"
+
+Goal of this stage: enough detail to start prototyping or to discuss architecture.
+
+### Stage 3 — Decide whether to prototype
+
+**Role: Architect.**
+
+If open design questions remain — visual, UX, **or CLI / API / architecture / data
+model** — invoke `mm:prototyping` to compare options before committing. Prototyping is
+not only a UI tool; any decision with several plausible options can be prototyped.
+
+If the decisions are already settled enough to name and write down, skip to stage 4.
+State which you are doing and why: *"The data model has three plausible shapes — worth
+prototyping. The sync trigger is settled. I'll prototype the model, then we frame."*
+
+When `mm:prototyping` runs inside roadmapping, it returns its locked-in decisions to you
+rather than writing its own output doc. Fold those decisions into the framing stage. See
+`references/composition.md`.
+
+### Stage 4 — Framing
+
+**Roles: Architect + Devil's advocate.**
+
+This is the last highly-interactive stage, and the most important. Take the loose
+thinking from stages 2–3 and make it crisp. The human's attention diminishes after this
+point, so getting the concepts precise now is what makes the durable docs possible.
+
+Produce precise agreement on four things (see `references/framing-guide.md` for how):
+
+- **Names** — every concept has a clear, agreed name. An unnamed concept cannot be
+  written into a contract or an issue.
+- **Boundaries** — related ideas grouped into concepts, with explicit lines between them.
+  This becomes the per-doc split in `concepts/`.
+- **Dependencies** — what depends on what; what must exist before what. This drives issue
+  sequencing in stage 5.
+- **Constraints** — the fixed points the design must respect.
+
+This is also where the roadmap earns its name — propose the folder rename here (see File
+setup and naming).
+
+**Checkpoint:** Ask, in roughly these words:
+
+> "Here are the concepts, their boundaries, and the dependency order: <summary>. Are
+> these the right names and the right groupings? Anything mis-bounded? Once you say yes,
+> I'll canonize these into the durable docs and you'll review the writing, not the
+> structure."
+
+The bar: you are confident you can canonize everything discussed into durable
+architectural docs without coming back to the human for structural clarification.
+
+### Stage 5 — Wrap up and hand off
+
+**Role: Author.** Everything from here is agent-led. The human reviews; they do not
+co-author.
+
+#### 5a. Propose the doc plan
+
+List which docs are durable (→ `concepts/`) and which are ephemeral (→ `notes/`). Give
+3–5 bullet points of intended content per doc. Present it like this:
+
+```
+Durable (concepts/, committed):
+  concepts/source-layer.md
+    - the source abstraction and what every source must implement
+    - the sync lifecycle: fetch, normalize, store
+    - how source-specific config is isolated
+  concepts/normalization.md
+    - the normalized record shape all sources map into
+    - ...
+
+Ephemeral (notes/<roadmap>/session-prep/, gitignored → issues):
+  session-prep/01-source-interface.md  → issue: define the source interface
+  session-prep/02-first-source.md      → issue: implement the first source
+  ...
+```
+
+**Get the human's buy-in on the plan before writing anything.** Adjust until they
+approve.
+
+#### 5b. Write the durable docs first
+
+For each durable doc, in dependency order: draft it from the framing, apply
+`mm:writing-guidelines`, then present it. **Checkpoint per doc:** *"Here's
+`concepts/<name>.md`. Reviewable, or want changes?"* Get approval before the next doc.
+Write each approved doc to disk immediately.
+
+#### 5c. Produce session-prep docs
+
+One per issue, in `notes/<roadmap-name>/session-prep/`, numbered in implementation
+order. These are more prescriptive than the durable contracts — they describe the build
+steps for one slice. Use the template in `references/issue-sequencing.md`.
+
+#### 5d. File the issues in order
+
+File in implementation order so issue numbers encode the sequence. Cross-link
+dependencies; supersede any stale existing issues. See `references/issue-sequencing.md`.
+
+#### 5e. Resolve follow-ups
+
+Surface each item in `follow-ups.md` and ask whether it becomes its own issue, input to
+a future roadmap, or is discarded. Record the disposition next to each item.
+
+#### 5f. Hand off
+
+Summarize the chain: what implements what, what blocks what, what can run in parallel.
+End with the ordered issue list and any parallelizable groups called out.
+
+## Scaling
+
+Adapt the depth to the size of the feature set:
+
+- **Large feature set** (5+ features, multiple shared concepts) — all five stages,
+  multiple durable docs, full dependency graph.
+- **Small feature set** (2–4 features, one shared concept) — run all stages but expect
+  one or two durable docs and a short dependency chain. Do not skip framing; a small set
+  still benefits from named concepts and explicit ordering.
+- **Borderline (one feature?)** — if stage 1 reveals it is really one feature, stop and
+  route to `mm:planning`. Do not stretch a single feature into a roadmap.
+
+The stages do not change with size; the number of artifacts does.
+
+## Composition
+
+- `mm:prototyping` — invoked in stage 3 when design questions warrant comparison. See
+  `references/composition.md` for how the two skills hand off.
+- `mm:writing-guidelines` — applied to every durable doc before it is presented.
+- `mm:planning` — available per-issue after the roadmap is sequenced (usually
+  unnecessary).
+- `superpowers:using-git-worktrees` — for an isolated workspace, so planning artifacts
+  do not disturb the working branch.
+
+## Autocatalyst environments
+
+If running inside an autocatalyst workspace, the session is already isolated — do not
+create your own worktree. Durable docs still go to `{docs_root}/concepts/`; ephemeral
+docs still go to `{docs_root}/notes/`. See `references/autocatalyst-adaptation.md`.
+
+## Writing style
+
+When drafting any durable doc, follow `mm:writing-guidelines` for style, tone, and
+anti-jargon principles.

--- a/plugins/mm/skills/roadmapping/agents/openai.yaml
+++ b/plugins/mm/skills/roadmapping/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "mm roadmapping"
+  short_description: "Plan a feature set at an inflection point"
+  default_prompt: "Use $roadmapping to plan the next several features as a group."

--- a/plugins/mm/skills/roadmapping/references/artifact-tiers.md
+++ b/plugins/mm/skills/roadmapping/references/artifact-tiers.md
@@ -1,0 +1,92 @@
+# Artifact tiers
+
+Roadmapping produces two tiers of document. Keeping them distinct is what makes a
+roadmapping session produce clean, reviewable output instead of a pile of mixed notes.
+
+## Durable docs — `{docs_root}/concepts/`
+
+**Committed to the repository.** These are architectural contracts. They describe the
+shared design of the feature set: the concepts, their boundaries, what depends on what,
+and the constraints. They outlive the session.
+
+- **Audience:** anyone who later implements one of the issues, and anyone reviewing the
+  architecture months from now.
+- **Style:** descriptive and precise. State the contract, not the build steps. Apply
+  `mm:writing-guidelines` before presenting.
+- **Granularity:** one doc per concept or concern, whichever scales better. A feature
+  set with four distinct layers usually wants four docs.
+- **Lifecycle:** drafted in stage 5, reviewed per doc, committed.
+
+A good durable doc reads like a reference a future implementer consults to understand
+how their slice fits the whole — not a task list.
+
+### Concept doc template
+
+```markdown
+---
+created: YYYY-MM-DD
+last_updated: YYYY-MM-DD
+status: active
+roadmap: <slug>
+---
+
+# <Concept name>
+
+One-paragraph statement of what this concept is and the boundary around it — what it
+owns and what it explicitly does not.
+
+## Contract
+
+The rules anything touching this concept must honor. State them as invariants, not
+suggestions.
+
+## Structure
+
+The shape: the entities, interfaces, or data the concept defines. Use fenced blocks for
+schemas, signatures, or types.
+
+## Relationships
+
+What this concept depends on, and what depends on it. Link sibling concept docs.
+
+## Constraints and decisions
+
+Fixed points the design must respect, and the non-obvious decisions made during
+roadmapping (with the one-line reason each was chosen).
+
+## Open edges
+
+Known extension points or deferred questions — what later work may add without breaking
+this contract.
+```
+
+Not every section is required for every concept. Keep the ones that carry weight; drop
+the rest rather than padding.
+
+## Ephemeral docs — `{docs_root}/notes/<roadmap-name>/`
+
+**Gitignored.** These are working artifacts for the session and the implementations
+that follow.
+
+- `brainstorm.md` — loose thinking and decisions captured during stages 1–2.
+- `follow-ups.md` — out-of-scope tangents, held so the human is not anxious about losing
+  them. Resolved at wrap-up.
+- `session-prep/<issue-slug>.md` — one prep doc per issue. Becomes the issue body. See
+  the template in `issue-sequencing.md`.
+
+- **Audience:** the agent running a specific implementation session.
+- **Style:** prescriptive. Describe the build steps for one slice of the contract.
+- **Lifecycle:** created in stages 1–2 (brainstorm, follow-ups) and stage 5
+  (session-prep), then discarded or left for the human to clean up.
+
+## The key distinction
+
+The durable doc describes the **contract**. The session-prep doc describes the **build
+steps** for one slice of that contract. The session-prep is therefore more prescriptive
+and more detailed than the durable doc it implements. This separation is what keeps the
+committed `concepts/` docs clean: implementation detail lives in `notes/`, not in the
+durable contract.
+
+A quick test when you are unsure where something belongs: *will a future implementer of
+a different slice need this?* If yes, it is contract — put it in `concepts/`. If it only
+matters to the one issue in front of you, it is build detail — put it in session-prep.

--- a/plugins/mm/skills/roadmapping/references/autocatalyst-adaptation.md
+++ b/plugins/mm/skills/roadmapping/references/autocatalyst-adaptation.md
@@ -1,0 +1,31 @@
+# Autocatalyst adaptation
+
+Roadmapping runs the same way inside an autocatalyst workspace, with two adjustments.
+
+## Detecting the environment
+
+You are in an autocatalyst workspace if the working path is under an autocatalyst
+workspaces directory (for example, a path containing `.autocatalyst/workspaces/`). When
+in doubt, check whether the session was started by autocatalyst rather than directly by
+the human.
+
+## Adjustment 1 — no self-worktree
+
+An autocatalyst workspace is already isolated. Do **not** create your own git worktree
+or invoke `superpowers:using-git-worktrees`. Work in the provided workspace.
+
+## Adjustment 2 — same artifact destinations
+
+Artifact destinations do not change:
+
+- Durable docs → `{docs_root}/concepts/` (committed).
+- Ephemeral docs → `{docs_root}/notes/<roadmap-name>/` (gitignored).
+
+## Hand-off
+
+The issues you file in stage 5 are the hand-off. When autocatalyst later picks up an
+issue, it generates a per-issue implementation session from the issue body — which is
+the session-prep doc you wrote. Make sure each session-prep doc stands alone: it must
+include the slice description, a link to the relevant `concepts/` doc, build steps,
+acceptance criteria, and dependencies, so the implementing session can act without the
+roadmapping conversation's context.

--- a/plugins/mm/skills/roadmapping/references/composition.md
+++ b/plugins/mm/skills/roadmapping/references/composition.md
@@ -1,0 +1,32 @@
+# Composition with prototyping
+
+Roadmapping and `mm:prototyping` compose. Roadmapping calls prototyping in stage 3 when
+the feature set has open design questions worth comparing. Prototyping also runs
+standalone, outside any roadmap.
+
+## When roadmapping invokes prototyping
+
+Invoke `mm:prototyping` from stage 3 when one or more decisions in the feature set have
+several plausible options and comparing them live would produce a better answer than
+arguing them in the abstract. This applies to any kind of decision — visual, UX, CLI,
+API, architecture, or data model.
+
+Skip prototyping when the decisions are already settled enough to name and write down in
+framing.
+
+## The hand-off back
+
+When `mm:prototyping` runs **inside** roadmapping, it does not write its own output doc
+and does not ask the human where decisions should land. Instead it returns its locked-in
+decisions to roadmapping. You fold those decisions into stage 4 (framing) and they
+become part of the durable `concepts/` docs.
+
+This is the one behavioral difference for prototyping when composed: standalone
+prototyping asks where its decisions land; composed prototyping hands them back to the
+parent. See the wrap-up section of `mm:prototyping`.
+
+## Roadmapping does not require prototyping
+
+Stage 3 is a decision, not a mandate. If the architecture is clear, go straight from
+brainstorm (stage 2) to framing (stage 4). Prototyping is a tool for resolving open
+questions, not a required step.

--- a/plugins/mm/skills/roadmapping/references/framing-guide.md
+++ b/plugins/mm/skills/roadmapping/references/framing-guide.md
@@ -1,0 +1,96 @@
+# Framing guide
+
+Framing (stage 4) is where loose thinking becomes precise enough to write down. It is
+the last highly-interactive stage. After it, the human reviews but no longer co-authors,
+so the concepts must be crisp before you leave this stage.
+
+## What framing produces
+
+Framing does not produce a document. It produces shared, precise agreement on four
+things, which the durable docs then capture:
+
+1. **Names.** Every concept the feature set introduces has a clear, agreed name. Vague
+   references ("the thing that handles syncing") become named concepts ("the sync
+   coordinator"). Naming is not cosmetic — an unnamed concept cannot be referenced in a
+   contract or an issue.
+
+2. **Boundaries.** Related ideas are grouped into concepts, and the line between concepts
+   is explicit. What belongs to concept A, what belongs to concept B, and what is shared.
+   This is what later becomes the per-doc split in `concepts/`.
+
+3. **Dependencies.** What depends on what. Which concept must exist before another can be
+   built. This ordering drives issue sequencing in stage 5.
+
+4. **Constraints.** The fixed points the design must respect — existing architecture,
+   platform limits, decisions already made in ADRs.
+
+## The framing worksheet
+
+Work through this with the human, capturing the result in `brainstorm.md`. The filled
+worksheet is the raw material for the doc plan in stage 5.
+
+```
+Concepts
+  <name> — <one line: what it owns, and the boundary>
+  <name> — ...
+
+Boundaries (what is NOT in each concept, where it's ambiguous)
+  <name> owns X but NOT Y; Y lives in <other concept>
+
+Dependencies (A → B means B depends on A)
+  <name> → <name>
+  <name> → <name>
+
+Constraints
+  - <fixed point: existing architecture / platform / prior ADR>
+```
+
+A worked shape, for a multi-source sync feature set:
+
+```
+Concepts
+  source-interface — what every source must implement (fetch, auth, identity)
+  normalization    — the common record shape sources map into
+  sync-coordinator — schedules and runs syncs; owns retry/backoff
+  source-config    — per-source settings, isolated so one source can't leak into another
+
+Dependencies
+  source-interface → normalization
+  source-interface → sync-coordinator
+  source-config    → sync-coordinator
+
+Constraints
+  - tokens never persisted in the DB (per ADR on secret storage)
+  - first source ships behind a flag
+```
+
+## How to run it
+
+- Take the open items from `brainstorm.md` and the locked-in decisions from any
+  prototyping, and turn each into a named, bounded concept.
+- Draw the dependency graph out loud with the human. Disagreement here is cheap to
+  resolve now and expensive later.
+- Watch for two failure modes: a concept that is really two concepts (split it), and two
+  "concepts" that are really one (merge them). Boundary errors here propagate into the
+  docs and the issues.
+- Name the constraints explicitly, even the obvious ones — they become the "Constraints
+  and decisions" section of each concept doc.
+
+## The exit bar
+
+You are done framing when you are confident you can canonize everything discussed into
+durable architectural docs without going back to the human for clarification. Concretely:
+
+- [ ] Every concept has a name you could put in a file path.
+- [ ] For every concept, you can state in one sentence what it does *not* own.
+- [ ] The dependency order is acyclic and agreed.
+- [ ] Every constraint is written down.
+
+If you cannot yet write a clean contract for a concept, it is not framed — keep working
+it with the human while their attention is still high.
+
+## Rename the roadmap here
+
+By stage 4 the feature set has a clear identity. Propose renaming the session folder
+from `roadmap-YYYY-MM-DD` to `roadmap-<slug>` so the durable and ephemeral artifacts
+carry a meaningful name into the future.

--- a/plugins/mm/skills/roadmapping/references/inflection-points.md
+++ b/plugins/mm/skills/roadmapping/references/inflection-points.md
@@ -1,0 +1,78 @@
+# Inflection points
+
+Every roadmap has natural boundaries — points where a group of work forms a coherent
+planning unit. These are inflection points. Roadmapping works best when scoped to one
+inflection point at a time: large enough that planning the group beats planning each
+feature alone, small enough to hold in one session.
+
+## Why plan at an inflection point
+
+Some work must be planned as a group or the architecture comes out wrong. The classic
+case: a project will eventually support several data sources, but only the first one is
+in front of you. If you plan that first source without knowing others are coming, you
+will bake single-source assumptions into the architecture and pay to undo them later.
+Planning the source-handling layer once, with all known sources in mind, produces the
+right abstraction the first time.
+
+The test: **does planning these features together change the architecture versus
+planning them one at a time?** If yes, they belong in one roadmap. If no, they are
+probably independent features — use `mm:planning` for each.
+
+## Recognizing an inflection point
+
+An inflection point usually shows up as:
+
+- A foundational capability that several later features will build on (a shared layer,
+  a core abstraction, a primary surface).
+- A decision that is expensive to reverse once features depend on it.
+- A cluster of features that all touch the same new subsystem.
+
+Common shapes (illustrative, not exhaustive):
+
+- Establishing the foundational design system or token set.
+- Laying out the application shell — the structural frame other features mount into.
+- A multi-source or multi-provider integration layer, planned with all known
+  sources/providers in mind.
+- A primary content surface plus its configuration and settings.
+
+## Bounding the scope
+
+In stage 1, sanity-check the scope against both edges:
+
+- **Too small** — if the work is effectively one feature, there is no shared
+  architecture to design. Route to `mm:planning`.
+- **Too large** — if the work spans many inflection points ("everything we want to
+  build"), it cannot be planned well in one session. Help the human pick the nearest
+  inflection point and scope to that. The rest becomes a follow-up.
+
+### Bounding checklist
+
+Run these checks before committing to the scope:
+
+- [ ] Is there shared infrastructure two or more features depend on? (If no → likely one
+      feature → `mm:planning`.)
+- [ ] Would planning them together change the architecture versus one at a time? (If no
+      → independent features → `mm:planning` each.)
+- [ ] Can the set be held in one session — a handful of features, not dozens? (If no →
+      too large → scope to the nearest inflection point.)
+- [ ] Are the prerequisites already in place, or at least named? (If a prerequisite is
+      missing → see Sequencing below.)
+
+## Sequencing across inflection points
+
+Inflection points have a natural order: later ones depend on earlier ones landing. Part
+of stage 1 is confirming the prerequisites are in place. The critical question is not
+only "can we plan this?" but **"should we plan this now, or does an earlier inflection
+point need to land first?"** Planning a feature set on top of an unbuilt foundation
+produces a roadmap built on guesses.
+
+Two cases when a prerequisite is missing:
+
+- **Missing and unplanned** — stop. The prerequisite is itself an earlier inflection
+  point. Propose roadmapping or planning that first.
+- **Missing but already designed** (its contract exists in `concepts/` or an ADR) — you
+  can plan on top of the contract, noting the dependency explicitly so the sequencing in
+  stage 5 puts the prerequisite's implementation first.
+
+When in doubt, ask the human directly: *"This roadmap leans on X. X isn't built yet — is
+it far enough along that we can plan against it, or should we set course on X first?"*

--- a/plugins/mm/skills/roadmapping/references/issue-sequencing.md
+++ b/plugins/mm/skills/roadmapping/references/issue-sequencing.md
@@ -1,0 +1,93 @@
+# Issue sequencing and session prep
+
+Stage 5 turns the framed feature set into a sequenced backlog. Each issue gets one
+session-prep doc that becomes its body. The sequence encodes the dependency order from
+framing.
+
+## Session-prep docs
+
+One doc per issue, in `{docs_root}/notes/<roadmap-name>/session-prep/<NN>-<slug>.md`,
+where `NN` is the implementation order. These are ephemeral and gitignored.
+
+A session-prep doc is **prescriptive** — it describes how to build one slice of the
+feature set, for the agent that will implement it. Unlike the durable contract in
+`concepts/`, which states what the design is, the session-prep states what to do.
+
+### Session-prep template
+
+```markdown
+# <Issue title>
+
+## Slice
+What this issue covers, and how it fits the feature set. One paragraph.
+
+## Contract
+Link the relevant `concepts/` doc(s). State which parts of the contract this slice
+implements. Do not restate the contract — link it.
+
+## Build steps
+1. <ordered, concrete step>
+2. ...
+Keep these prescriptive. This is the part that distinguishes session-prep from the
+durable doc.
+
+## Acceptance criteria
+- [ ] <observable, testable condition>
+- [ ] ...
+
+## Dependencies
+- Depends on: #<n> (<why>)
+- Blocks: #<n>
+
+## Out of scope
+What this issue deliberately does not do, so the implementer doesn't expand it.
+```
+
+Keep contract detail in `concepts/` and build detail in session-prep. Do not duplicate
+the contract into every prep doc — link to it.
+
+## Filing order
+
+File issues in implementation order so that issue numbers reflect the sequence:
+
+1. Topologically sort the issues by the dependency graph from framing. Foundations
+   first; dependents after. Where two issues have no dependency between them, either
+   order is fine — flag them as parallelizable.
+2. File each issue, using its session-prep doc as the body.
+3. Cross-link dependencies: each issue names the issues it depends on and the issues
+   that depend on it. Use the tracker's native linking where available; otherwise put
+   `Depends on #N` / `Blocks #N` in the body.
+4. Identify which issues can run in parallel — work with no dependency between them — and
+   say so in each issue and in the hand-off summary.
+
+## Superseding stale issues
+
+A roadmap often touches work that already has open issues. For each:
+
+- **Now covered by the roadmap** — supersede it: link the new issue, close or annotate
+  the old one (*"Superseded by #N as part of the <roadmap> roadmap"*), and note the
+  replacement.
+- **Now wrong** (the roadmap changed the design) — update or close it and explain why in
+  one line.
+- **Still independent** — leave it alone; not everything is part of the roadmap.
+
+Do not leave stale issues that contradict the roadmap — they will mislead whoever picks
+them up.
+
+## Hand-off summary
+
+Close stage 5 with a summary the human (or the next agent) can act on cold:
+
+```
+Roadmap: <slug>
+Durable docs: concepts/<a>.md, concepts/<b>.md
+
+Issues, in order:
+  #12 define the source interface           (no deps)
+  #13 normalization record shape            (depends #12)
+  #14 sync coordinator                      (depends #12)        ┐ parallel with #13
+  #15 first source: implement + flag        (depends #13, #14)
+
+Parallelizable: #13 and #14 after #12 lands.
+Superseded: #9 (old single-source issue) → #15.
+```

--- a/plugins/mm/skills/roadmapping/references/research-offload.md
+++ b/plugins/mm/skills/roadmapping/references/research-offload.md
@@ -1,0 +1,29 @@
+# Offloading research
+
+Roadmapping sometimes needs research that would flood the main conversation — surveying
+how comparable products solve a problem, reading a large external spec, or mapping an
+unfamiliar subsystem. Offload this to a sub-agent so the main session stays focused on
+the human and the design.
+
+## When to offload
+
+- The research is read-heavy and would produce far more context than the decision needs.
+- The question is well-scoped enough to delegate ("how do comparable tools handle saved
+  views — grouping, filtering, sorting, layout, property visibility?").
+- The answer is an input to the design, not the design itself.
+
+## How to offload
+
+Dispatch a research sub-agent with a precise question and the specific output you need
+back — a short structured summary, not a transcript. Keep the main session interactive
+with the human while the sub-agent works.
+
+When the sub-agent returns, capture the distilled findings in `brainstorm.md` so the
+decision they inform is traceable, then continue the conversation.
+
+## What not to offload
+
+- The goal and scope decisions in stage 1 — these require the human.
+- Framing in stage 4 — naming and boundaries are the human-facing core of the skill.
+
+Research informs these stages; it does not replace the human's role in them.


### PR DESCRIPTION
## Summary

Adds two new skills and bumps mm to **2.3.0**.

- **`mm:roadmapping`** — plans several related features as a group at a project inflection point, rather than one feature at a time. Produces durable architectural contracts in `concepts/` plus a sequenced backlog of issues prepped in `notes/`. Five-stage process (establish goal → brainstorm → decide-whether-to-prototype → framing → wrap-up/hand-off) with per-stage checkpoints, a two-tier artifact model, inflection-point bounding, roles, and scaling. Distinct from `mm:planning`, which stays single-feature scoped.
- **`mm:prototyping`** — answers a design question by comparison: ordered experiments, a few variants per experiment differing on one axis, the human picks a winner, the winner folds into the baseline. Works for UI, UX, CLI, API, architecture, and data-model decisions. Composes with `mm:roadmapping` or runs standalone.

## How they fit together

`mm:roadmapping` invokes `mm:prototyping` in stage 3 when open design questions warrant live comparison; prototyping hands its locked-in decisions back to roadmapping rather than writing its own output. `mm:planning` cross-links to roadmapping when a single-feature session turns out to span several features that share architecture.

## Artifact model

- Durable architectural contracts → `{docs_root}/concepts/` (committed).
- Ephemeral working notes, follow-ups, and per-issue session prep → `{docs_root}/notes/` (gitignored).

No new config setting — both live under the existing `docs_root`.

## Changes

- `feat(roadmapping)` — new skill: SKILL.md + 7 references + agents/openai.yaml
- `feat(prototyping)` — new skill: SKILL.md + 5 references + agents/openai.yaml
- `docs(planning)` — DON'T-use bullet + routing block to roadmapping
- `chore` — bump version in both plugin.json files; register both skills in codex keywords/prompts and the README

Reference links verified (no dangling/orphaned docs); both plugin.json files validate.

Closes #61
