### PR TITLE
fix: define lab setup and variant controls contract in mm:prototyping

### DIFF
--- a/plugins/mm/skills/prototyping/SKILL.md
+++ b/plugins/mm/skills/prototyping/SKILL.md
@@ -70,10 +70,16 @@ alignment on where you are headed.
 
 ### 3. Set up the lab
 
-Build throwaway scaffolding inside the running system, reachable by a quick toggle — a
-keyboard shortcut, a route flag, an env var, whatever fits the project. Variants live in
-a clearly-named throwaway location so they are easy to find and delete later. See
-`references/lab-setup-patterns.md`.
+Build throwaway scaffolding inside the running system. During an active prototyping
+session, launch directly into the experiment by default; use the shortcut or control as
+the escape hatch back to the normal app, not as the only way into the lab. Variants live
+in a clearly-named throwaway location so they are easy to find and delete later. Lab
+chrome must be discoverable but unobtrusive, recessed in a consistent location by
+default, and separated from the experiment's visual hierarchy. Use stable selectors such
+as `1..N` for variant switching after checking host shortcut collisions, and make the
+visible variant label start with the same selector the human uses. Put experiment
+framing and per-variant explanations in a dismissable surface instead of persistent
+chrome. See `references/lab-setup-patterns.md`.
 
 ### 4. Run one experiment
 
@@ -96,16 +102,18 @@ For each experiment, loop:
 
 Present every experiment the same way so the human can compare quickly:
 
-```
+```text
 Experiment N: <axis> — <the tradeoff at stake>
 Holding constant: <what is the same across all variants>
 
-  A — <name>: <one line on what's different and why you'd pick it>
-  B — <name>: <one line>
-  C — <name>: <one line>
+  1 — <name>: <one line on what's different and why you'd pick it>
+  2 — <name>: <one line>
+  3 — <name>: <one line>
 
-How to see them: <toggle instructions — key, flag, route>
+How to see them: <direct launch path plus checked shortcuts/controls; labels match selectors>
 ```
+
+Use as many numbered entries as the experiment has variants, normally two to five; do not introduce a second identity such as `A/B/C` when the lab controls use numeric selectors.
 
 Then stop and let the human look. Do not recommend a winner unless asked — you propose
 the options; the human picks. If asked for your lean, give it with a one-line reason.

--- a/plugins/mm/skills/prototyping/SKILL.md
+++ b/plugins/mm/skills/prototyping/SKILL.md
@@ -130,7 +130,7 @@ point, not a script. Choose one and say which and why:
 - **Add** an axis the last experiment surfaced.
 - **Stop early** — sometimes the design is settled before the plan is exhausted.
 
-State it plainly: *"Locked in B. That settles the row layout but raises a density
+State it plainly: *"Locked in 2. That settles the row layout but raises a density
 question I didn't plan — want to run that next, or move to the empty state as planned?"*
 
 ### 6. Watch for meta-lessons

--- a/plugins/mm/skills/prototyping/references/experiment-design.md
+++ b/plugins/mm/skills/prototyping/references/experiment-design.md
@@ -43,7 +43,10 @@ can reorder once a winner changes what matters.
   genuinely wider. More than five means the axis is too broad — split it or run a second
   round to narrow first.
 - **Name each variant** for what makes it distinct ("attached titlebar", "footer
-  toggle"), not "A/B/C" alone. The name is how the decision gets remembered.
+  toggle"), and pair that name with the lab selector. If the selector is `1`, write the
+  visible identity as `1 — attached titlebar`. The name is how the decision gets
+  remembered, but the selector is how the human switches; do not create a second visible
+  identity such as `A` for the same variant.
 
 ## When an experiment produces no winner
 

--- a/plugins/mm/skills/prototyping/references/lab-setup-patterns.md
+++ b/plugins/mm/skills/prototyping/references/lab-setup-patterns.md
@@ -37,27 +37,38 @@ against the real system.
 
 ## Patterns by surface
 
-- **Web / desktop UI** — a dev-only route or view, gated by a query flag or env var.
-  Numeric keys switch variants. Variant components live in a dedicated throwaway
-  directory and import only existing tokens and shared primitives.
-- **CLI** — a hidden subcommand or a flag that selects the variant behavior. Each variant
-  is a separate handler behind the selector.
-- **API / service** — a variant route or a header/flag that selects the implementation.
-  Each variant is isolated behind the selector so none leaks into the real routes.
+- **Web / desktop UI** — a dev-only route, view, query flag, or env var that opens the
+  active lab directly while the session is running. Use `1..N` to switch variants after
+  checking host shortcuts. Keep persistent controls recessed in the upper-right by
+  default, with details in a dismissable modal or equivalent surface. Variant components
+  live in a dedicated throwaway directory and import only existing tokens and shared
+  primitives.
+- **CLI** — a hidden subcommand or explicit flag that opens the active lab directly,
+  plus `1..N` selector values when interactive switching is available. Check existing
+  flags, subcommands, shell aliases documented by the project, and common terminal
+  control keys before choosing selectors. Show variant labels as `1 — <name>` in help
+  text and prompts.
+- **API / service** — a variant route, header, query parameter, or config value that
+  selects the implementation. Check existing route, header, query, and config names
+  before choosing selectors. Expose labels as `1 — <name>` in logs, response metadata,
+  or the run sheet so the selector and visible identity match.
 - **Architecture / data model** — a small spike that exercises each variant against
-  realistic data, with the variant selected by config. The goal is to feel the tradeoff,
-  not to ship the spike.
+  realistic data, with the variant selected by config, script argument, or fixture name.
+  Check existing config keys, scripts, and fixture names before choosing selectors. The
+  goal is to feel the tradeoff, not to ship the spike.
 
 ## Worked example — web UI lab
 
-A lab for comparing row layouts in a list view, gated by a query flag, variants switched
-by number keys:
+A lab for comparing row layouts in a list view. The active prototyping launch command or
+URL opens the lab directly, variants switch with checked `1..N` shortcuts, and lab
+chrome stays recessed while details live in a dismissable modal:
 
-```
+```text
 src/lab/                         # clearly-not-production; deleted at wrap-up
-  README.md                      # what this is, how to enter, that it's throwaway
-  Lab.tsx                        # reads ?lab=1, switches variant by number key 1..N
-  registry.ts                    # [{ id, name, Component }]
+  README.md                      # what this is, how to launch, that it's throwaway
+  Lab.tsx                        # active lab shell; 1..N keys switch variants
+  LabChrome.tsx                  # upper-right recessed controls + details modal
+  registry.ts                    # [{ shortcut, name, summary, tradeoffs, Component }]
   fixtures.ts                    # realistic fixture data, shaped like production
   variants/
     1-single-line.tsx
@@ -65,14 +76,56 @@ src/lab/                         # clearly-not-production; deleted at wrap-up
     3-card.tsx
 ```
 
-- `Lab.tsx` mounts only when the flag is present; the real app is untouched otherwise.
-- Each variant imports the real design tokens and shared primitives — no bespoke
-  styling — so what the human sees is what production will feel like.
+- Launch the active session directly into `Lab.tsx`. If safety requires a gate, make it
+  explicit in the command or URL, such as `npm run dev -- --lab=row-layout` or
+  `/orders?lab=row-layout`, instead of relying on a memorized hidden entry shortcut.
+- Before binding `1`, `2`, and `3`, check the host app's shortcut map and obvious
+  browser/OS collisions. If a collision exists, choose the nearest non-conflicting
+  selector and make the visible label match it.
+- `LabChrome.tsx` keeps persistent lab controls discoverable but unobtrusive in the
+  upper-right by default: current variant, compact switcher, details button, and exit
+  control. It should be visually recessed and must not look like part of any variant.
+- The details button opens a dismissable modal with the experiment title, axis, what is
+  held constant, each variant's explanation, why it was chosen, and pros/tradeoffs.
+- `registry.ts` owns the selector-visible identity so labels match shortcuts everywhere:
+
+```ts
+export const variants = [
+  {
+    shortcut: "1",
+    name: "single-line",
+    summary: "Keeps every row compact for fast scanning.",
+    tradeoffs: "Lowest height, but secondary metadata has less room.",
+    Component: SingleLineVariant,
+  },
+  {
+    shortcut: "2",
+    name: "two-line",
+    summary: "Gives title and metadata separate rows.",
+    tradeoffs: "More readable metadata, but fewer items fit above the fold.",
+    Component: TwoLineVariant,
+  },
+  {
+    shortcut: "3",
+    name: "card",
+    summary: "Groups row content in a larger card-like surface.",
+    tradeoffs: "Strong separation between records, but the list feels heavier.",
+    Component: CardVariant,
+  },
+];
+```
+
+- Present labels from the registry as `1 — single-line`, `2 — two-line`, and `3 — card`
+  in chrome, modal content, logs, and spoken/written instructions.
+- Each variant imports the real design tokens and shared primitives — no bespoke styling
+  — so what the human sees is what production will feel like.
 - One variant per file keeps them independent: deleting a loser touches nothing else.
 
-The same shape maps to other surfaces: a `--lab=2` flag selecting a CLI handler, a
-`?lab=2` route selecting a service implementation, a config key selecting a data-model
-spike.
+The same shape maps to other surfaces: a `--lab=row-layout --variant=2` flag selecting a
+CLI handler, a `?lab=row-layout&variant=2` route selecting a service implementation, or
+a config key selecting a data-model spike. In each case, the selector is checked for
+collisions, shown in the label, and documented as the direct entry path for the active
+session.
 
 ## Keep it honest and disposable
 

--- a/plugins/mm/skills/prototyping/references/lab-setup-patterns.md
+++ b/plugins/mm/skills/prototyping/references/lab-setup-patterns.md
@@ -43,7 +43,7 @@ against the real system.
   default, with details in a dismissable modal or equivalent surface. Variant components
   live in a dedicated throwaway directory and import only existing tokens and shared
   primitives.
-- **CLI** — a hidden subcommand or explicit flag that opens the active lab directly,
+- **CLI** — a dev-only subcommand or explicit flag that opens the active lab directly,
   plus `1..N` selector values when interactive switching is available. Check existing
   flags, subcommands, shell aliases documented by the project, and common terminal
   control keys before choosing selectors. Show variant labels as `1 — <name>` in help

--- a/plugins/mm/skills/prototyping/references/lab-setup-patterns.md
+++ b/plugins/mm/skills/prototyping/references/lab-setup-patterns.md
@@ -9,8 +9,29 @@ against the real system.
 - **Inside the real system.** Variants should run against the same tokens, styles, data
   shapes, and platform mechanics that production uses, so comparisons are honest. A
   variant that lies about the real environment produces a decision you cannot trust.
-- **Quick toggle.** Switching between variants must be fast — a keypress or a flag, not a
-  rebuild. Slow switching kills comparison.
+- **Active labs open directly.** During an active prototyping session, launch into the
+  experiment by default. The shortcut or affordance is the escape hatch back to the
+  normal app, not the only way into the lab. If the host cannot safely open directly
+  into a lab, make the entry point explicit in the launch command, URL, or first visible
+  instruction so the human never has to remember an undocumented shortcut.
+- **Chrome recedes.** Lab controls must be discoverable but unobtrusive. Put persistent
+  controls in a consistent recessed location by default, such as the upper-right for
+  visual surfaces, and keep them out of the experiment's visual hierarchy. The controls
+  should read as lab furniture, not as part of the variant under test.
+- **Framing is dismissable.** Put the experiment title, axis, per-variant explanations,
+  why each variant was chosen, and pros/tradeoffs in a modal, popover, side panel, or
+  equivalent dismissable surface with enough room. Do not use a persistent header band
+  that competes visually with the experiment.
+- **Shortcuts are stable and checked.** Use `1..N` as the default variant-switch
+  convention. Before binding keys, inspect the host app's documented shortcuts,
+  obvious browser/OS shortcuts, and existing lab or development shortcuts; ask the
+  human when collisions are unclear. For CLI, API, architecture, and data-model labs,
+  map this check to existing flags, routes, headers, config keys, scripts, or command
+  names before choosing the lab selector.
+- **Visible identity matches the gesture.** If the key, flag, route, or config value is
+  `1`, the visible variant label starts with `1`. Do not label the same variant as `A`
+  in one place and `1` somewhere else. Pair the stable selector with a descriptive name,
+  such as `1 — attached titlebar`.
 - **Clearly throwaway.** Variants live in a clearly-named location that is obviously not
   production, so they are easy to find and delete later.
 

--- a/plugins/mm/skills/prototyping/references/meta-lessons.md
+++ b/plugins/mm/skills/prototyping/references/meta-lessons.md
@@ -1,14 +1,13 @@
 # Meta-lessons
 
-Some feedback in an experiment is not "I pick variant B." It is a signal that the
+Some feedback in an experiment is not "I pick 2." It is a signal that the
 experiment is framed wrong. These are the recurring patterns worth watching for. Each
 has a trigger, the reframe, and an example.
 
 ## Variants-as-values: the axis is one level deeper
 
 **Trigger.** You find yourself proposing a set of variants where each variant is one
-possible *value* on some dimension. Variant A sorts by date, variant B sorts by
-priority, variant C sorts by status.
+possible *value* on some dimension. 1 — sort by date, 2 — sort by priority, 3 — sort by status.
 
 **The reframe.** When the variants are just different values, the real design question is
 usually one level up: *how does the user choose the value, and where is that choice


### PR DESCRIPTION
## Summary

- lab-setup-patterns.md: Replaced 3-bullet Principles section with 7-bullet interaction contract covering active-lab launch, recessed chrome, dismissable framing, stable 1..N shortcuts with collision checks, visible identity matching gesture, and cross-surface guidance for CLI/API/architecture labs.
- lab-setup-patterns.md: Rewrote Patterns by surface and Worked example sections — added LabChrome.tsx, a registry with shortcut/name/summary/tradeoffs/Component shape, 1/2/3 label conventions, and dismissable details modal; replaced gated-only example with direct-launch model.
- SKILL.md: Updated stage 3 paragraph to cover direct-launch default, escape hatch framing, recessed chrome, and dismissable framing; replaced A/B/C variant format with 1/2/3; added sentence prohibiting a second identity when controls use numeric selectors; updated stale 'Locked in B' example to 'Locked in 2'.
- experiment-design.md: Expanded Name each variant bullet to pair variant name with lab selector (1 — attached titlebar format) and explicitly prohibit creating a second visible identity like A for the same variant.
- roadmapping/references/composition.md: Verified as non-conflicting — no lab entry, launch, shortcut, or chrome behavior defined; no changes needed.

## Verify

- [ ] Run rg -n "A —|B —|C —" plugins/mm/skills/prototyping/SKILL.md and confirm no output (A/B/C removed as canonical variant identities).
- [ ] Run rg -n "Active labs open directly|Chrome recedes|Framing is dismissable|Shortcuts are stable and checked|Visible identity matches the gesture" plugins/mm/skills/prototyping/references/lab-setup-patterns.md and confirm all 5 principle headers appear.
- [ ] Open lab-setup-patterns.md and verify the Worked example section shows LabChrome.tsx in the directory tree, a TypeScript registry with shortcut/name/summary/tradeoffs/Component fields, and 1 — single-line / 2 — two-line / 3 — card label format.
- [ ] Open SKILL.md and verify the variant presentation format block uses 1 — / 2 — / 3 — labels and includes the sentence about not introducing a second identity like A/B/C.
- [ ] Verify roadmapping/references/composition.md is unchanged and contains no lab/launch/shortcut/chrome language.

## Test steps

1. cd /Users/mark.stafford/.autocatalyst/workspaces/micromanager/b9b27cfd-245f-4095-8a8e-11bff6ccfe1c
2. rg -n "Active labs open directly|Chrome recedes|Framing is dismissable|Shortcuts are stable and checked|Visible identity matches the gesture" plugins/mm/skills/prototyping/references/lab-setup-patterns.md
3. rg -n "A —|B —|C —" plugins/mm/skills/prototyping/SKILL.md
4. rg -n "1 — <name>|do not introduce a second identity" plugins/mm/skills/prototyping/SKILL.md
5. rg -n "LabChrome|1 — single-line|2 — two-line|3 — card|shortcut, name, summary, tradeoffs" plugins/mm/skills/prototyping/references/lab-setup-patterns.md
6. rg -n "pair that name with the lab selector|do not create a second visible identity" plugins/mm/skills/prototyping/references/experiment-design.md
7. rg -n "lab|launch|shortcut" plugins/mm/skills/roadmapping/references/composition.md

Closes #62