### PR TITLE
chore: chore(prototyping): adopt roadmapping scaffolding and confirm decision altitude

### DIFF
--- a/plugins/mm/skills/prototyping/SKILL.md
+++ b/plugins/mm/skills/prototyping/SKILL.md
@@ -52,11 +52,20 @@ Before planning experiments, establish what you are exploring:
   feature (standalone)?
 - Read the relevant repository docs first — the design system, related features, any
   existing contracts the design must fit.
+- State the decision outcome in one or two sentences: what settling this decision
+  unlocks for the project or the feature set.
+- State the target altitude, such as field list, layout, mechanism, architecture, data
+  model, workflow, or feature-set shape.
+- Ask the human to confirm or correct the outcome and altitude before listing axes. If
+  they correct it, adjust your context before moving to step 2.
 
-Only once the context is clear should you plan experiments. A prototype that ignores the
-existing design system or an adjacent feature's contract wastes a round. Say what
-constraints you found: *"The design system fixes the accent color and the sidebar width,
-so those are constant across all variants — we're only varying the row layout."*
+Only once the context, outcome, and altitude are clear should you plan experiments. A
+prototype that ignores the existing design system, an adjacent feature's contract, or the
+actual level of the decision wastes a round. Say what constraints you found and what
+altitude you think the decision targets: *"The design system fixes the accent color and
+the sidebar width, so those are constant across all variants. Settling this unlocks the
+source-selection workflow, and I think the target altitude is workflow shape rather than
+row styling. Is that right?"*
 
 ### 2. Plan the experiments
 

--- a/plugins/mm/skills/prototyping/references/cleanup.md
+++ b/plugins/mm/skills/prototyping/references/cleanup.md
@@ -1,6 +1,6 @@
 # Cleanup
 
-The lab is throwaway. Once the decisions are captured (see `wrap-up.md`), remove it.
+The lab is throwaway. Once the decisions and follow-ups are captured in the destination chosen during wrap-up (see `wrap-up.md`), remove it.
 
 ## What to delete
 
@@ -12,7 +12,9 @@ The lab is throwaway. Once the decisions are captured (see `wrap-up.md`), remove
 
 ## What to preserve
 
-- The decision summary, in whatever destination the wrap-up step chose.
+- The decision summary or durable concept docs, in whatever destination the wrap-up step
+  chose.
+- Human-owned follow-ups, in the durable artifact or issue the wrap-up step chose.
 - Anything the human explicitly asks to promote toward production. Promote it
   deliberately — rewrite or cherry-pick it into the real code on a proper branch, rather
   than leaving lab-shaped code behind. Lab code carries throwaway assumptions that should
@@ -26,5 +28,4 @@ The lab is throwaway. Once the decisions are captured (see `wrap-up.md`), remove
 3. Delete, and confirm the lab no longer activates (the toggle is gone, the system runs
    as it did before the lab).
 
-A clean exit leaves the system exactly as it was before the lab, plus the captured
-decisions.
+A clean exit leaves the system exactly as it was before the lab, plus the captured decisions and any human-owned follow-ups.

--- a/plugins/mm/skills/prototyping/references/experiment-design.md
+++ b/plugins/mm/skills/prototyping/references/experiment-design.md
@@ -4,6 +4,18 @@ An experiment is one axis with a few variants. The quality of a prototyping sess
 mostly decided here: a well-chosen axis produces a clean decision, a muddy axis produces
 variants the human cannot compare.
 
+## Confirm the level of the question first
+
+A plan can be internally coherent and still answer the wrong question. Before choosing
+axes, confirm the outcome and altitude with the human: what settling the decision
+unlocks, and whether the target is a field list, layout, mechanism, architecture, data
+model, workflow, feature-set shape, or another level.
+
+If the target is one level higher than you first assumed, redesign the axes around the
+higher-level decision instead of optimizing the narrower question. This check prevents
+choosing the wrong set of axes. The shallow-axis warning below is different: it helps you
+recover when one specific axis is too narrow after the session is already underway.
+
 ## Choosing axes
 
 An axis is a single dimension of the design that has several plausible settings. Good

--- a/plugins/mm/skills/prototyping/references/wrap-up.md
+++ b/plugins/mm/skills/prototyping/references/wrap-up.md
@@ -39,19 +39,103 @@ parent skill. Roadmapping folds the decisions into its durable `concepts/` docs.
 write your own output doc and do not ask the human where decisions go — the parent owns
 that.
 
-**If standalone:** ask the human where the decisions should land. Offer:
+**If standalone:** ask the human where the decisions should land. For a substantial
+session, recommend detailed concept docs in `{docs_root}/concepts/` unless the human
+chooses another durable destination. Use `notes/` for throwaway seed material, not for
+durable decisions.
+
+Offer these destinations:
 
 - **a. Fold into an existing durable doc** — the human names the path; you edit it.
-- **b. Seed doc** — write the decision summary to
-  `{docs_root}/notes/<experiment-name>/decisions.md`. This is a working artifact that
-  feeds a later `mm:planning` or `mm:roadmapping` session. It lives under `notes/`, which
-  is gitignored; the human decides whether to keep it under version control.
-- **c. Issue body** — create a new issue, or update an existing one, with the decisions.
-- **d. Just exit** — the human takes the summary from the conversation themselves.
+- **b. Detailed concept docs** — write durable docs under
+  `{docs_root}/concepts/<experiment-or-topic>/` or the repository's established concepts
+  path. Choose this for substantial standalone sessions where future implementers need
+  the decisions as a contract.
+- **c. Seed doc** — write the decision summary to
+  `{docs_root}/notes/<experiment-name>/decisions.md` only for lightweight or working
+  material. This can feed a later `mm:planning` or `mm:roadmapping` session, but it is
+  not the durable home for substantial decisions.
+- **d. Issue body** — create a new issue, or update an existing one, with the decisions.
+- **e. Just exit** — leave the summary in chat only when the human explicitly wants no
+  artifact.
 
-Phrase it as a question: *"Decisions are captured. Where should they live — fold into an
-existing doc, drop a seed doc in `notes/`, put them on an issue, or just leave them
-here?"* Apply `mm:writing-guidelines` to whatever you write.
+Phrase it as a recommendation plus a choice: *"Decisions are captured. This was a
+substantial standalone session, so I recommend durable concept docs under
+`{docs_root}/concepts/<experiment-or-topic>/`. Should I write those, fold the decisions
+into an existing doc, create a lightweight `notes/` seed, put them on an issue, or leave
+them here?"* Apply `mm:writing-guidelines` to whatever you write.
+
+### Durable concept-doc plan
+
+Before writing durable concept docs for a standalone session, propose a short doc plan
+and get the human's approval. The plan should:
+
+- List each durable doc under `{docs_root}/concepts/<experiment-or-topic>/` or another
+  repository-appropriate concepts path.
+- Split by concern when the session spans unrelated domains, such as read/preview
+  behavior versus write behavior.
+- Include three to five bullets of intended content for each doc.
+- State whether a separate follow-up artifact is needed.
+- Ask the human to approve or revise the split before you write.
+
+Read an existing concept doc or repository exemplar first, then match its depth and
+voice. Detailed concept docs are the deliverable for substantial standalone sessions, not
+a thin decision summary. Durable docs should describe the contract: boundaries,
+invariants, structure, relationships, constraints, and non-obvious decisions with their
+reasons. Do not copy roadmapping's issue-sequencing behavior into prototyping unless the
+human asks for issues.
+
+Use this doc-plan shape:
+
+```markdown
+I recommend these durable docs:
+
+1. `{docs_root}/concepts/<experiment-or-topic>/<concern-a>.md`
+   - Contract this concern owns.
+   - Decisions from experiments that constrain it.
+   - Relationships to adjacent concepts.
+   - Open edges future work may extend.
+2. `{docs_root}/concepts/<experiment-or-topic>/<concern-b>.md`
+   - Contract this concern owns.
+   - Decisions from experiments that constrain it.
+   - Relationships to adjacent concepts.
+   - Open edges future work may extend.
+3. `{docs_root}/concepts/<experiment-or-topic>/follow-ups.md`
+   - Human tasks.
+   - Future roadmap inputs.
+   - Future issue candidates.
+   - Items explicitly discarded.
+
+Approve this split, or adjust it before I write the docs?
+```
+
+### Follow-ups
+
+Human-owned follow-ups must go to a durable, human-visible artifact, never agent memory.
+A throwaway lab increases the need to write follow-ups into the real repository or a
+human-owned issue; it is not a reason to keep them in memory.
+
+For substantial standalone sessions, create or update a follow-up artifact such as
+`{docs_root}/concepts/<experiment-or-topic>/follow-ups.md` or another
+repository-appropriate path, unless the human chooses issue tracking instead. Record each
+follow-up under one of these outcomes:
+
+- **Human task** — something the human agreed to do.
+- **Future roadmap input** — a topic to consider in a later `mm:roadmapping` session.
+- **Future issue** — a candidate issue to file when the human is ready.
+- **Discarded** — a tangent the human explicitly chose not to pursue.
+
+### Durable artifact branch and PR handling
+
+Durable docs must not be written directly onto a repository's main branch or normal
+working branch when the repository convention requires branch and PR review. In normal
+interactive sessions, create or use an appropriate feature branch and open a PR for
+durable artifacts.
+
+In Autocatalyst-managed runs, the workspace already owns branch and PR management. Do
+not create worktrees, create or switch branches, push, merge, or open PRs when the
+environment provides those steps. Use the same artifact destinations, but leave branch
+and PR operations to Autocatalyst.
 
 ## 3. Clean up the lab
 

--- a/plugins/mm/skills/prototyping/references/wrap-up.md
+++ b/plugins/mm/skills/prototyping/references/wrap-up.md
@@ -54,7 +54,11 @@ Offer these destinations:
 - **c. Seed doc** — write the decision summary to
   `{docs_root}/notes/<experiment-name>/decisions.md` only for lightweight or working
   material. This can feed a later `mm:planning` or `mm:roadmapping` session, but it is
-  not the durable home for substantial decisions.
+  not the durable home for substantial decisions. Before writing here, check that
+  `{docs_root}/notes/` is listed in `.gitignore`. If it is not, add it and tell the
+  human: *"Added `{docs_root}/notes/` to `.gitignore` — seed notes stay local; use
+  `concepts/` for committed decisions."* If the human prefers not to modify `.gitignore`,
+  use `concepts/` or an issue instead.
 - **d. Issue body** — create a new issue, or update an existing one, with the decisions.
 - **e. Just exit** — leave the summary in chat only when the human explicitly wants no
   artifact.


### PR DESCRIPTION
## Summary

- SKILL.md: Added outcome and altitude confirmation bullets to 'Set context' step, requiring the assistant to state what the decision unlocks and ask the human to confirm the target altitude before listing experiment axes.
- experiment-design.md: Inserted 'Confirm the level of the question first' section before 'Choosing axes', naming the wrong-altitude failure mode and distinguishing it from the existing shallow-axis warning.
- wrap-up.md: Replaced the standalone destination list with a five-option artifact-tier flow including durable concept docs, concern-based doc planning with human approval, follow-up artifact guidance (never agent memory), and branch/PR handling that exempts Autocatalyst-managed runs.
- wrap-up.md (convergence fix): Option c (seed doc) now requires the assistant to verify {docs_root}/notes/ is listed in .gitignore before writing there, matching roadmapping's gitignore guidance.
- cleanup.md: Updated three sentences to include follow-ups alongside decisions, so the lab is only removed after both decisions and follow-ups are captured.

## Verify

- [ ] Composed mm:roadmapping behavior is unchanged: prototyping still returns lock-ins to the parent and does not write standalone docs or ask where decisions land.
- [ ] The branch/PR guidance in wrap-up.md correctly tells Autocatalyst-managed runs not to create worktrees, branches, pushes, merges, or PRs.
- [ ] Option c in wrap-up.md now reads: 'Before writing here, check that {docs_root}/notes/ is listed in .gitignore...' with a fallback to concepts/ or an issue.
- [ ] The doc-plan template and follow-up categories (Human task, Future roadmap input, Future issue, Discarded) appear correctly in wrap-up.md.
- [ ] All four files pass the targeted rg acceptance check and the git diff shows only the four expected prototyping Markdown files changed.

## Test steps

1. cd /Users/mark.stafford/.autocatalyst/workspaces/micromanager/785fc629-17c9-4ac5-ba09-b0234dce01f6
2. rg -n "gitignore" plugins/mm/skills/prototyping/references/wrap-up.md
3. rg -n "outcome|altitude|wrong question|higher-level decision|concepts|follow-ups|agent memory|branch|PR|Autocatalyst|roadmapping" plugins/mm/skills/prototyping/SKILL.md plugins/mm/skills/prototyping/references/experiment-design.md plugins/mm/skills/prototyping/references/wrap-up.md plugins/mm/skills/prototyping/references/cleanup.md
4. Read plugins/mm/skills/prototyping/references/wrap-up.md lines 50-70 to verify option c includes gitignore check and fallback guidance

Closes #63