### PR TITLE
fix: fix(mm:prototyping): isolate lab workspace preflight and route feature sets

### DIFF
--- a/plugins/mm/skills/prototyping/SKILL.md
+++ b/plugins/mm/skills/prototyping/SKILL.md
@@ -79,16 +79,26 @@ alignment on where you are headed.
 
 ### 3. Set up the lab
 
-Build throwaway scaffolding inside the running system. During an active prototyping
-session, launch directly into the experiment by default; use the shortcut or control as
-the escape hatch back to the normal app, not as the only way into the lab. Variants live
-in a clearly-named throwaway location so they are easy to find and delete later. Lab
-chrome must be discoverable but unobtrusive, recessed in a consistent location by
-default, and separated from the experiment's visual hierarchy. Use stable selectors such
-as `1..N` for variant switching after checking host shortcut collisions, and make the
-visible variant label start with the same selector the human uses. Put experiment
-framing and per-variant explanations in a dismissable surface instead of persistent
-chrome. See `references/lab-setup-patterns.md`.
+Before writing any lab files, isolate the workspace. If the session is running in an
+Autocatalyst-managed workspace, the workspace is already isolated: do not create a
+worktree, switch branches, push, merge, or open a PR. If the session is not already
+isolated, use an available worktree skill or native worktree flow before creating lab
+files; if the repository has a different documented isolation convention, follow that
+convention and say what you are using. A branch in the same working directory is not
+sufficient isolation for throwaway lab files; untracked and temporary files dirty the
+user's active checkout regardless of which branch is checked out.
+
+Build throwaway scaffolding inside the running system only after that isolation preflight
+is complete. During an active prototyping session, launch directly into the experiment by
+default; use the shortcut or control as the escape hatch back to the normal app, not as
+the only way into the lab. Variants live in a clearly named throwaway location inside the
+isolated workspace so they are easy to find and delete later. Lab chrome must be
+discoverable but unobtrusive, recessed in a consistent location by default, and separated
+from the experiment's visual hierarchy. Use stable selectors such as `1..N` for variant
+switching after checking host shortcut collisions, and make the visible variant label
+start with the same selector the human uses. Put experiment framing and per-variant
+explanations in a dismissable surface instead of persistent chrome. See
+`references/lab-setup-patterns.md`.
 
 ### 4. Run one experiment
 

--- a/plugins/mm/skills/prototyping/references/lab-setup-patterns.md
+++ b/plugins/mm/skills/prototyping/references/lab-setup-patterns.md
@@ -32,8 +32,12 @@ against the real system.
   `1`, the visible variant label starts with `1`. Do not label the same variant as `A`
   in one place and `1` somewhere else. Pair the stable selector with a descriptive name,
   such as `1 — attached titlebar`.
-- **Clearly throwaway.** Variants live in a clearly-named location that is obviously not
-  production, so they are easy to find and delete later.
+- **Clearly throwaway means isolated and disposable.** Variants live in an isolated
+  workspace first, then in a clearly named location inside that workspace that is
+  obviously not production. A directory such as `src/lab/` makes cleanup easy, but it is
+  not sufficient by itself if creating it would dirty the human's active checkout. Regardless, before
+  choosing paths, check repository conventions for existing `proto/`, `spike/`, lab, or
+  branch/workspace naming patterns and follow them when they exist.
 
 ## Patterns by surface
 
@@ -59,9 +63,11 @@ against the real system.
 
 ## Worked example — web UI lab
 
-A lab for comparing row layouts in a list view. The active prototyping launch command or
-URL opens the lab directly, variants switch with checked `1..N` shortcuts, and lab
-chrome stays recessed while details live in a dismissable modal:
+A lab for comparing row layouts in a list view. This `src/lab/` directory is inside the
+already isolated prototyping workspace; it is not a substitute for workspace isolation.
+The active prototyping launch command or URL opens the lab directly, variants switch with
+checked `1..N` shortcuts, and lab chrome stays recessed while details live in a
+dismissable modal:
 
 ```text
 src/lab/                         # clearly-not-production; deleted at wrap-up
@@ -129,8 +135,12 @@ session.
 
 ## Keep it honest and disposable
 
+- Confirm the workspace is isolated before the first lab write. In Autocatalyst-managed
+  runs, use the provided workspace and do not create another worktree or switch branches.
 - Use real fixture data shaped like production data.
 - Do not wire the lab into real persistence, routing, or side effects.
 - Keep each variant self-contained so it can be deleted without touching the others.
+- Keep the lab path easy to remove, such as `src/lab/`, `proto/<topic>/`, or the
+  repository's existing spike location, inside the isolated workspace.
 - Expect to delete all of it at wrap-up. Anything worth keeping is promoted deliberately,
   not left behind in the lab.

--- a/plugins/mm/skills/prototyping/references/wrap-up.md
+++ b/plugins/mm/skills/prototyping/references/wrap-up.md
@@ -39,10 +39,34 @@ parent skill. Roadmapping folds the decisions into its durable `concepts/` docs.
 write your own output doc and do not ask the human where decisions go — the parent owns
 that.
 
-**If standalone:** ask the human where the decisions should land. For a substantial
-session, recommend detailed concept docs in `{docs_root}/concepts/` unless the human
-chooses another durable destination. Use `notes/` for throwaway seed material, not for
-durable decisions.
+**If standalone:** first check whether the lock-ins describe one feature or a feature set
+with multiple implementation slices. Use this tripwire when the session settled several
+related decisions whose implementation has dependencies, parallel tracks, or foundations
+that other slices build on. Say the classification plainly: *"This prototype settled a
+feature set, not just one feature, because the source contract must land before the
+normalization and sync slices can proceed."*
+
+If the output is feature-set-sized and the framing is not complete enough to hand off —
+contracts are not drafted, slice boundaries are unnamed, or dependencies are unclear —
+route to `mm:roadmapping` and hand it the lock-in summary, open/deferred items, and any
+constraints discovered in the lab. If the framing is already complete — contracts
+drafted, slices named, dependencies identified — propose a dependency-ordered issue set
+using the sequencing logic in
+`plugins/mm/skills/roadmapping/references/issue-sequencing.md`: foundations first,
+dependents after, cross-links for dependencies, parallelizable work called out. Adapt the
+sequencing logic to the standalone context; do not assume the roadmapping session-prep
+file tree exists. Ask whether to file those issues using the configured issue tracker: *"I
+can file these as implementation issues in order. Want me to do that, leave them as a
+draft, or adjust the sequencing first?"* If the tracker is Jira or another unsupported
+provider, do not promise GitHub issue creation; provide the ordered issue bodies for the
+human or tracker-specific workflow instead. In Autocatalyst-managed runs, do not create
+worktrees, switch branches, push, merge, or open PRs; branch and PR management belongs to
+Autocatalyst.
+
+If the standalone output is one feature, or the human declines issue sequencing, ask where
+the decisions should land. For a substantial session, recommend detailed concept docs in
+`{docs_root}/concepts/` unless the human chooses another durable destination. Use
+`notes/` for throwaway seed material, not for durable decisions.
 
 Offer these destinations:
 
@@ -86,8 +110,9 @@ Read an existing concept doc or repository exemplar first, then match its depth 
 voice. Detailed concept docs are the deliverable for substantial standalone sessions, not
 a thin decision summary. Durable docs should describe the contract: boundaries,
 invariants, structure, relationships, constraints, and non-obvious decisions with their
-reasons. Do not copy roadmapping's issue-sequencing behavior into prototyping unless the
-human asks for issues.
+reasons. Do not copy the full roadmapping workflow into prototyping. Only use roadmapping's
+issue-sequencing reference when the standalone feature-set tripwire above fires and the
+settled framing is complete enough to propose implementation issues safely.
 
 Use this doc-plan shape:
 


### PR DESCRIPTION
## Summary

- `plugins/mm/skills/prototyping/SKILL.md`: Lab setup (### 3) now requires an isolation preflight before any lab writes. Autocatalyst-managed workspaces are recognized as already isolated; non-isolated sessions must use a worktree skill or native worktree flow; a branch alone is explicitly insufficient.
- `plugins/mm/skills/prototyping/references/lab-setup-patterns.md`: 'Clearly throwaway' is redefined as isolated AND disposable. src/lab/ is framed as a path inside an already-isolated workspace, not sufficient isolation by itself. 'Keep it honest and disposable' now opens with a workspace-isolation confirmation step.
- `plugins/mm/skills/prototyping/references/wrap-up.md`: Standalone sessions now check whether lock-ins describe one feature or a feature set. Feature-set output with incomplete framing routes to mm:roadmapping; complete framing proposes a dependency-ordered issue set using roadmapping's issue-sequencing reference. Cautions Jira/unsupported trackers and Autocatalyst PR management. Composed mm:roadmapping behavior is unchanged.

## Verify

- [ ] Under '### 3. Set up the lab' in SKILL.md, the first paragraph starts with 'Before writing any lab files, isolate the workspace.' and mentions Autocatalyst, worktree flow, and branch-alone insufficiency.
- [ ] In lab-setup-patterns.md, the 'Clearly throwaway means isolated and disposable.' bullet explains that src/lab/ is not sufficient by itself and instructs checking repo conventions.
- [ ] In wrap-up.md, the 'If invoked by mm:roadmapping' paragraph is unchanged and still returns the lock-in summary to the parent without writing standalone output.
- [ ] In wrap-up.md, the standalone block includes concrete criteria for 'framing complete enough': contracts drafted, slices named, dependencies identified.
- [ ] All three files are the only files changed across the 3 commits (git diff --stat 2733301..HEAD confirms this).

## Test steps

1. cd /Users/mark.stafford/.autocatalyst/workspaces/micromanager/920541ba-4298-4f3a-9d89-d1f75e142b30
2. sed -n '/### 3\. Set up the lab/,/### 4\. Run one experiment/p' plugins/mm/skills/prototyping/SKILL.md
3. sed -n '/## Principles/,/## Patterns by surface/p' plugins/mm/skills/prototyping/references/lab-setup-patterns.md
4. sed -n '/## Keep it honest and disposable/,$p' plugins/mm/skills/prototyping/references/lab-setup-patterns.md
5. sed -n '/## 2\. Decide where the decisions land/,/Offer these destinations/p' plugins/mm/skills/prototyping/references/wrap-up.md
6. rg -n "isolated|worktree|Autocatalyst|throwaway|feature set|issue-sequencing|dependency|implementation order" plugins/mm/skills/prototyping/SKILL.md plugins/mm/skills/prototyping/references/lab-setup-patterns.md plugins/mm/skills/prototyping/references/wrap-up.md plugins/mm/skills/roadmapping/references/issue-sequencing.md plugins/mm/skills/roadmapping/references/autocatalyst-adaptation.md

Closes #64